### PR TITLE
firefox is an unsupported browser

### DIFF
--- a/Calling/ClientApp/src/Utils/Utils.ts
+++ b/Calling/ClientApp/src/Utils/Utils.ts
@@ -36,6 +36,11 @@ export const utils = {
   isSmallScreen() {
     return window.innerWidth < 700 || window.innerHeight < 400;
   },
+  isUnsupportedBrowser() {
+    return window.navigator.userAgent.match(/(Firefox)/g)
+      ? true
+      : false;
+  },
   getId: (identifier: CommunicationUser | CallingApplication | UnknownIdentifier | PhoneNumber): string => {
     if (isCommunicationUser(identifier)) {
       return identifier.communicationUserId;

--- a/Calling/ClientApp/src/core/sideEffects.ts
+++ b/Calling/ClientApp/src/core/sideEffects.ts
@@ -108,8 +108,8 @@ export const initCallClient = (userId: string, unsupportedStateHandler: () => vo
 
       var callClient;
 
-      // check if chrome/ios
-      if (utils.isOnIphoneAndNotSafari()) {
+      // check if chrome on ios OR firefox browser
+      if (utils.isOnIphoneAndNotSafari() || utils.isUnsupportedBrowser()) {
         unsupportedStateHandler();
         return;
       }


### PR DESCRIPTION
## Purpose
Firefox is not a supported browser by the calling JS SDK. We need to block the ability to start a call if we detect the user is on firefox. Since this is a sample we are only going to do this via user agent.

## Does this introduce a breaking change?
No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
 Ran it in chrome to make sure it worked and then ran it in firefox. Put in breakpoints to verify its seeing the unsupported page because its getting false from the unsupportedBrowser function

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->