### PR TITLE
Only init callAgent once on configuration screen

### DIFF
--- a/Calling/ClientApp/src/App.tsx
+++ b/Calling/ClientApp/src/App.tsx
@@ -34,8 +34,6 @@ const App = () => {
     return () => window.removeEventListener('resize', setWindowWidth);
   }, []);
 
-  const createUserId = () => 'user' + Math.ceil(Math.random() * 1000);
-
   const getGroupIdFromUrl = () => {
     const urlParams = new URLSearchParams(window.location.search);
     return urlParams.get('groupId');
@@ -66,7 +64,6 @@ const App = () => {
           unsupportedStateHandler={() => setPage('error')}
           endCallHandler={() => setPage('endCall')}
           groupId={getGroupId()}
-          userId={createUserId()}
           screenWidth={screenWidth}
         />
       );
@@ -75,7 +72,6 @@ const App = () => {
         <GroupCall
           endCallHandler={() => setPage('endCall')}
           groupId={getGroupId()}
-          userId={createUserId()}
           screenWidth={screenWidth}
         />
       );

--- a/Calling/ClientApp/src/Utils/Utils.ts
+++ b/Calling/ClientApp/src/Utils/Utils.ts
@@ -15,8 +15,8 @@ export const utils = {
   getAppServiceUrl: (): string => {
     return window.location.origin;
   },
-  getTokenForUser: async (userId: string): Promise<any> => {
-    const response = await fetch('/userToken?userId='.concat(encodeURIComponent(userId)));
+  getTokenForUser: async (): Promise<any> => {
+    const response = await fetch('/userToken');
     if (response.ok) {
       return response.json();
     }

--- a/Calling/ClientApp/src/components/Configuration.tsx
+++ b/Calling/ClientApp/src/components/Configuration.tsx
@@ -60,7 +60,7 @@ export default (props: ConfigurationScreenProps): JSX.Element => {
     setUserId(userId);
     initCallClient(userId, unsupportedStateHandler, endCallHandler);
     setGroup(groupId);
-  }, [userId, groupId, setUserId, initCallClient, setGroup, unsupportedStateHandler, endCallHandler]);
+  }, []);
 
   return (
     <Stack className={mainContainerStyle} horizontalAlign="center" verticalAlign="center">

--- a/Calling/ClientApp/src/components/Configuration.tsx
+++ b/Calling/ClientApp/src/components/Configuration.tsx
@@ -29,6 +29,7 @@ export interface ConfigurationScreenProps {
   callAgent: CallAgent;
   deviceManager: DeviceManager;
   setUserId(userId: string): void;
+  setDisplayName(displayName: string): void;
   initCallClient(userId: string, unsupportedStateHandler: () => void, endCallhandler: () => void): void;
   setGroup(groupId: string): void;
   startCallHandler(): void;
@@ -54,9 +55,10 @@ export default (props: ConfigurationScreenProps): JSX.Element => {
   const [name, setName] = useState(props.userId);
   const [emptyWarning, setEmptyWarning] = useState(false);
 
-  const { userId, groupId, setUserId, initCallClient, setGroup, unsupportedStateHandler, endCallHandler } = props;
+  const { userId, groupId, setUserId, setDisplayName, initCallClient, setGroup, unsupportedStateHandler, endCallHandler } = props;
 
   useEffect(() => {
+    // we want to set this user id so we can use it to identify the local user
     setUserId(userId);
     initCallClient(userId, unsupportedStateHandler, endCallHandler);
     setGroup(groupId);
@@ -101,8 +103,10 @@ export default (props: ConfigurationScreenProps): JSX.Element => {
                     setEmptyWarning(true);
                   } else {
                     setEmptyWarning(false);
-                    props.setUserId(name);
+                    // update the local display name for all of the other participants to see
                     props.callAgent.updateDisplayName(name);
+                    // update the local display name for local rendering
+                    setDisplayName(name);
                     props.startCallHandler();
                   }
                 }}

--- a/Calling/ClientApp/src/components/Configuration.tsx
+++ b/Calling/ClientApp/src/components/Configuration.tsx
@@ -28,9 +28,8 @@ export interface ConfigurationScreenProps {
   groupId: string;
   callAgent: CallAgent;
   deviceManager: DeviceManager;
-  setUserId(userId: string): void;
   setDisplayName(displayName: string): void;
-  initCallClient(userId: string, unsupportedStateHandler: () => void, endCallhandler: () => void): void;
+  initCallClient(unsupportedStateHandler: () => void, endCallhandler: () => void): void;
   setGroup(groupId: string): void;
   startCallHandler(): void;
   unsupportedStateHandler: () => void;
@@ -52,15 +51,15 @@ export default (props: ConfigurationScreenProps): JSX.Element => {
   const spinnerLabel = 'Initializing call client...';
   const buttonText = 'Start call';
 
-  const [name, setName] = useState(props.userId);
+  const createUserId = () => 'user' + Math.ceil(Math.random() * 1000);
+
+  const [name, setName] = useState(createUserId());
   const [emptyWarning, setEmptyWarning] = useState(false);
 
-  const { userId, groupId, setUserId, setDisplayName, initCallClient, setGroup, unsupportedStateHandler, endCallHandler } = props;
+  const {groupId, setDisplayName, initCallClient, setGroup, unsupportedStateHandler, endCallHandler} = props;
 
   useEffect(() => {
-    // we want to set this user id so we can use it to identify the local user
-    setUserId(userId);
-    initCallClient(userId, unsupportedStateHandler, endCallHandler);
+    initCallClient(unsupportedStateHandler, endCallHandler);
     setGroup(groupId);
   }, []);
 

--- a/Calling/ClientApp/src/components/GroupCall.tsx
+++ b/Calling/ClientApp/src/components/GroupCall.tsx
@@ -62,8 +62,10 @@ export default (props: GroupCallProps): JSX.Element => {
 
   useEffect(() => {
     if (attempts > 3) {
-      props.setAttempts(0);
       props.endCallHandler();
+      // after we switch the screen on the next tick we want to 
+      // set the attempts back to 0
+      setTimeout(()=> props.setAttempts(0), 0)
     }
     if (callAgent && !call) {
       joinGroup();

--- a/Calling/ClientApp/src/components/MediaGallery.tsx
+++ b/Calling/ClientApp/src/components/MediaGallery.tsx
@@ -7,6 +7,7 @@ import RemoteStreamMedia from './RemoteStreamMedia';
 
 export interface MediaGalleryProps {
   userId: string;
+  displayName: string;
   remoteParticipants: RemoteParticipant[];
   localVideoStream: LocalVideoStream;
 }
@@ -23,7 +24,7 @@ export default (props: MediaGalleryProps): JSX.Element => {
     (participants) => (participants && participants.length > 0 ? Math.ceil(Math.sqrt(participants.length + 1)) : 1),
     []
   );
-  const getMediaGalleryTilesForParticipants = (participants: RemoteParticipant[], userId: string) => {
+  const getMediaGalleryTilesForParticipants = (participants: RemoteParticipant[], userId: string, displayName: string) => {
     // create a RemoteStreamMedia component for every remote participant
     const remoteParticipantsMediaGalleryItems = participants.map((participant) => (
       <div className={mediaGalleryStyle}>
@@ -38,7 +39,7 @@ export default (props: MediaGalleryProps): JSX.Element => {
     // create a LocalStreamMedia component for the local participant
     const localParticipantMediaGalleryItem = (
       <div key={userId} className={mediaGalleryStyle}>
-        <LocalStreamMedia label={userId} stream={props.localVideoStream} />
+        <LocalStreamMedia label={displayName} stream={props.localVideoStream} />
       </div>
     );
 
@@ -61,7 +62,7 @@ export default (props: MediaGalleryProps): JSX.Element => {
         gridTemplateColumns: `repeat(${gridCol}, 1fr)`
       }}
     >
-      {getMediaGalleryTilesForParticipants(props.remoteParticipants, props.userId)}
+      {getMediaGalleryTilesForParticipants(props.remoteParticipants, props.userId, props.displayName)}
     </div>
   );
 };

--- a/Calling/ClientApp/src/components/ParticipantStack.tsx
+++ b/Calling/ClientApp/src/components/ParticipantStack.tsx
@@ -15,6 +15,7 @@ import { MicIcon, MicOffIcon } from '@fluentui/react-icons-northstar';
 
 export interface ParticipantStackProps {
   userId: string;
+  displayName: string;
   call: Call;
   callState: string;
   screenShareStreams: ParticipantStream[];
@@ -81,7 +82,7 @@ export default (props: ParticipantStackProps): JSX.Element => {
   });
   participants.push({
     key: `${props.userId} (You)`,
-    name: `${props.userId} (You)`,
+    name: `${props.displayName} (You)`,
     participant: undefined,
     state: 'Connected',
     isScreenSharing: activeScreenShareStream ? utils.getId(screenShareStream.user.identifier) === props.userId : false,

--- a/Calling/ClientApp/src/containers/Configuration.ts
+++ b/Calling/ClientApp/src/containers/Configuration.ts
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import ConfigurationScreen, { ConfigurationScreenProps } from '../components/Configuration';
 import { setGroup } from '../core/actions/calls';
-import { setUserId } from '../core/actions/sdk';
+import { setUserId, setDisplayName } from '../core/actions/sdk';
 import { setVideoDeviceInfo, setAudioDeviceInfo } from '../core/actions/devices';
 import { initCallClient, updateDevices } from '../core/sideEffects';
 import { setMic } from '../core/actions/controls';
@@ -33,6 +33,7 @@ const mapDispatchToProps = (dispatch: any) => ({
   initCallClient: (userId: string, unsupportedStateHandler: () => void, endCallHandler: () => void) =>
     dispatch(initCallClient(userId, unsupportedStateHandler, endCallHandler)),
   setUserId: (userId: string) => dispatch(setUserId(userId)),
+  setDisplayName: (displayName: string) => dispatch(setDisplayName(displayName)),
   setGroup: (groupId: string) => dispatch(setGroup(groupId)),
   updateDevices: () => dispatch(updateDevices())
 });

--- a/Calling/ClientApp/src/containers/Configuration.ts
+++ b/Calling/ClientApp/src/containers/Configuration.ts
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import ConfigurationScreen, { ConfigurationScreenProps } from '../components/Configuration';
 import { setGroup } from '../core/actions/calls';
-import { setUserId, setDisplayName } from '../core/actions/sdk';
+import { setDisplayName } from '../core/actions/sdk';
 import { setVideoDeviceInfo, setAudioDeviceInfo } from '../core/actions/devices';
 import { initCallClient, updateDevices } from '../core/sideEffects';
 import { setMic } from '../core/actions/controls';
@@ -12,7 +12,6 @@ import { setLocalVideoStream } from '../core/actions/streams';
 const mapStateToProps = (state: State, props: ConfigurationScreenProps) => ({
   deviceManager: state.devices.deviceManager,
   callAgent: state.calls.callAgent,
-  userId: state.sdk.userId || props.userId,
   group: state.calls.group,
   mic: state.controls.mic,
   screenWidth: props.screenWidth,
@@ -30,9 +29,8 @@ const mapDispatchToProps = (dispatch: any) => ({
   setMic: (mic: boolean) => dispatch(setMic(mic)),
   setAudioDeviceInfo: (deviceInfo: AudioDeviceInfo) => dispatch(setAudioDeviceInfo(deviceInfo)),
   setVideoDeviceInfo: (deviceInfo: VideoDeviceInfo) => dispatch(setVideoDeviceInfo(deviceInfo)),
-  initCallClient: (userId: string, unsupportedStateHandler: () => void, endCallHandler: () => void) =>
-    dispatch(initCallClient(userId, unsupportedStateHandler, endCallHandler)),
-  setUserId: (userId: string) => dispatch(setUserId(userId)),
+  initCallClient: (unsupportedStateHandler: () => void, endCallHandler: () => void) =>
+    dispatch(initCallClient(unsupportedStateHandler, endCallHandler)),
   setDisplayName: (displayName: string) => dispatch(setDisplayName(displayName)),
   setGroup: (groupId: string) => dispatch(setGroup(groupId)),
   updateDevices: () => dispatch(updateDevices())

--- a/Calling/ClientApp/src/containers/GroupCall.ts
+++ b/Calling/ClientApp/src/containers/GroupCall.ts
@@ -8,7 +8,7 @@ import { State } from '../core/reducers';
 import { callRetried } from 'core/actions/calls';
 
 const mapStateToProps = (state: State, props: GroupCallProps) => ({
-  userId: state.sdk.userId || props.userId,
+  userId: state.sdk.userId,
   callAgent: state.calls.callAgent,
   group: state.calls.group,
   screenWidth: props.screenWidth,

--- a/Calling/ClientApp/src/containers/MediaGallery.ts
+++ b/Calling/ClientApp/src/containers/MediaGallery.ts
@@ -4,6 +4,7 @@ import { State } from '../core/reducers';
 
 const mapStateToProps = (state: State) => ({
   userId: state.sdk.userId,
+  displayName: state.sdk.displayName,
   remoteParticipants: state.calls.remoteParticipants,
   localVideoStream: state.streams.localVideoStream
 });

--- a/Calling/ClientApp/src/containers/ParticipantStack.ts
+++ b/Calling/ClientApp/src/containers/ParticipantStack.ts
@@ -6,6 +6,7 @@ import { CommunicationUser, CallingApplication } from '@azure/communication-comm
 
 const mapStateToProps = (state: State) => ({
   userId: state.sdk.userId,
+  displayName: state.sdk.displayName,
   call: state.calls.call,
   callState: state.calls.callState,
   remoteParticipants: state.calls.remoteParticipants,

--- a/Calling/ClientApp/src/core/actions/sdk.ts
+++ b/Calling/ClientApp/src/core/actions/sdk.ts
@@ -1,8 +1,14 @@
 const SET_USERID = 'SET_USERID';
+const SET_DISPLAY_NAME = 'SET_DISPLAY_NAME';
 
 interface SetUserIdAction {
   type: typeof SET_USERID;
   userId: string;
+}
+
+interface SetDisplayNameAction {
+  type: typeof SET_DISPLAY_NAME;
+  displayName: string;
 }
 
 export const setUserId = (userId: string): SetUserIdAction => {
@@ -12,6 +18,15 @@ export const setUserId = (userId: string): SetUserIdAction => {
   };
 };
 
-export { SET_USERID };
+export const setDisplayName = (displayName: string): SetDisplayNameAction => {
+  return {
+    type: SET_DISPLAY_NAME,
+    displayName
+  };
+};
 
-export type SdkTypes = SetUserIdAction;
+export { SET_USERID, SET_DISPLAY_NAME };
+
+export type SdkTypes =
+  | SetUserIdAction
+  | SetDisplayNameAction;

--- a/Calling/ClientApp/src/core/reducers/sdk.ts
+++ b/Calling/ClientApp/src/core/reducers/sdk.ts
@@ -1,14 +1,21 @@
 import { Reducer } from 'redux';
-import { SET_USERID, SdkTypes } from '../actions/sdk';
+import { SET_USERID, SdkTypes, SET_DISPLAY_NAME } from '../actions/sdk';
 
 export interface SdkState {
   userId?: string;
+  displayName: string
 }
 
-export const sdkReducer: Reducer<SdkState, SdkTypes> = (state = {}, action: SdkTypes): SdkState => {
+const initialState: SdkState = {
+  displayName: ''
+};
+
+export const sdkReducer: Reducer<SdkState, SdkTypes> = (state = initialState, action: SdkTypes): SdkState => {
   switch (action.type) {
     case SET_USERID:
       return { ...state, userId: action.userId };
+    case SET_DISPLAY_NAME:
+      return { ...state, displayName: action.displayName }
     default:
       return state;
   }

--- a/Calling/ClientApp/src/core/sideEffects.ts
+++ b/Calling/ClientApp/src/core/sideEffects.ts
@@ -28,6 +28,7 @@ import {
   setVideoDeviceList,
   setDeviceManager
 } from './actions/devices';
+import { setUserId } from './actions/sdk';
 import { addScreenShareStream, resetStreams, removeScreenShareStream } from './actions/streams';
 import { State } from './reducers';
 
@@ -97,10 +98,10 @@ export const updateDevices = () => {
   };
 };
 
-export const initCallClient = (userId: string, unsupportedStateHandler: () => void, endCallHandler: () => void) => {
+export const initCallClient = (unsupportedStateHandler: () => void, endCallHandler: () => void) => {
   return async (dispatch: Dispatch, getState: () => State) => {
     try {
-      const tokenResponse = await utils.getTokenForUser(userId);
+      const tokenResponse = await utils.getTokenForUser();
 
       const options: CallClientOptions = {};
 
@@ -132,7 +133,8 @@ export const initCallClient = (userId: string, unsupportedStateHandler: () => vo
         return;
       }
 
-      callAgent.updateDisplayName(userId);
+      // We want to set the user id when we have it officially from the server
+      dispatch(setUserId(tokenResponse.value.user.id))
 
       let deviceManager: DeviceManager = await callClient.getDeviceManager();
 


### PR DESCRIPTION
## Purpose
If you refresh on the configuration screen it would trigger the useEffect to get hit twice. This would mean we would unfortunately try to set up the call agent again and it would fail. If we have an empty dependency list for the useEffect on the configuration screen then we will only trigger when we mount the component.

## Does this introduce a breaking change?
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

1. Ran it locally.
2. Get to the configuration screen.
3. Reload the page.
4. Without the fix it would trigger the useEffect twice.
5. With the fix it only triggers the useEffect once.

* Test the code

## What to Check
Verify that the following are valid


## Other Information
<!-- Add any other helpful information that may be needed here. -->