### PR TITLE
fixing no stream image and local preview

### DIFF
--- a/Calling/ClientApp/src/components/Header.tsx
+++ b/Calling/ClientApp/src/components/Header.tsx
@@ -53,15 +53,15 @@ export default (props: HeaderProps): JSX.Element => {
       : setSelectedPane(CommandPanelTypes.None);
   };
 
-  const handleLocalVideoOnOff = () => {
+  const handleLocalVideoOnOff = async () => {
     if (props.localVideoStream) {
-      props.call.stopVideo(props.localVideoStream);
+      await props.call.stopVideo(props.localVideoStream);
       props.setLocalVideoStream(undefined);
     } else {
       if (props.videoDeviceInfo) {
         const localVideoStream = new LocalVideoStream(props.videoDeviceInfo);
         props.setLocalVideoStream(localVideoStream);
-        props.call.startVideo(localVideoStream);
+        await props.call.startVideo(localVideoStream);
       }
     }
   };

--- a/Calling/ClientApp/src/components/LocalStreamMedia.tsx
+++ b/Calling/ClientApp/src/components/LocalStreamMedia.tsx
@@ -19,33 +19,44 @@ export default (props: LocalStreamMediaProps): JSX.Element => {
 
   const imageProps = {
     src: staticMediaSVG.toString(),
-    imageFit: ImageFit.contain
+    imageFit: ImageFit.contain,
+    styles: {
+      root: {
+        width: '100%',
+        height: '100%'
+      }
+    }
   };
 
   const { stream, label } = props;
 
-  const renderLocalStream = async () => {
-    if (stream) {
-      const renderer: Renderer = new Renderer(stream);
-      rendererView = await renderer.createView({ scalingMode: 'Crop', isMirrored: true });
+  useEffect(() => {
+    (async () => {
+      if (stream) {
+        const renderer: Renderer = new Renderer(stream);
+        rendererView = await renderer.createView({ scalingMode: 'Crop', isMirrored: true  });
 
-      const container = document.getElementById(Constants.LOCAL_VIDEO_PREVIEW_ID);
+        const container = document.getElementById(Constants.LOCAL_VIDEO_PREVIEW_ID);
 
-      if (container && container.childElementCount === 0) {
-        container.appendChild(rendererView.target);
-        setActiveStreamBeingRendered(true);
+        if (container && container.childElementCount === 0) {
+          container.appendChild(rendererView.target);
+          setActiveStreamBeingRendered(true);
+        }
+      } else {
+        if (rendererView) {
+          rendererView.dispose();
+          setActiveStreamBeingRendered(false);
+        }
       }
-    } else {
+    })();
+
+    return () => {
       if (rendererView) {
         rendererView.dispose();
         setActiveStreamBeingRendered(false);
       }
-    }
-  }
-
-  useEffect(() => {
-    renderLocalStream();
-  }, [stream, renderLocalStream]);
+    };
+  }, [stream]);
 
   return (
     <div className={mediaContainer}>
@@ -54,7 +65,7 @@ export default (props: LocalStreamMediaProps): JSX.Element => {
         className={localVideoContainerStyle}
         id={Constants.LOCAL_VIDEO_PREVIEW_ID}
       />
-      <Image {...imageProps}  style={{ display: activeStreamBeingRendered ? 'none' : 'block' }}/>
+      <Image {...imageProps} style={{display: activeStreamBeingRendered ? 'none' : 'block'}}/>
       <Label className={videoHint}>{label}</Label>
     </div>
   );

--- a/Calling/ClientApp/src/components/MediaGallery.tsx
+++ b/Calling/ClientApp/src/components/MediaGallery.tsx
@@ -37,7 +37,7 @@ export default (props: MediaGalleryProps): JSX.Element => {
 
     // create a LocalStreamMedia component for the local participant
     const localParticipantMediaGalleryItem = (
-      <div key={"localParticipantTile"} className={mediaGalleryStyle}>
+      <div key="localParticipantTile" className={mediaGalleryStyle}>
         <LocalStreamMedia label={displayName} stream={props.localVideoStream} />
       </div>
     );

--- a/Calling/ClientApp/src/components/RemoteStreamMedia.tsx
+++ b/Calling/ClientApp/src/components/RemoteStreamMedia.tsx
@@ -22,7 +22,13 @@ export default (props: RemoteStreamMediaProps): JSX.Element => {
 
   const imageProps = {
     src: staticMediaSVG.toString(),
-    imageFit: ImageFit.contain
+    imageFit: ImageFit.contain,
+    styles: {
+      root: {
+        width: '100%',
+        height: '100%'
+      }
+    }
   };
 
   const {label, stream} = props;
@@ -66,9 +72,9 @@ export default (props: RemoteStreamMediaProps): JSX.Element => {
 
   return (
     <div className={mediaContainer}>
-      <div style={{ display: activeStreamBeingRendered ? 'block' : 'none' }} className={mediaContainer} id={streamId} />
-      <Image {...imageProps} style={{ display: activeStreamBeingRendered ? 'none' : 'block' }} />
-      <Label className={videoHint}>{label}</Label>
+      <div style={{display: activeStreamBeingRendered ? 'block' : 'none' }} className={mediaContainer} id={streamId} />
+        <Image {...imageProps} style={{ display: activeStreamBeingRendered ? 'none' : 'block'}} />
+        <Label className={videoHint}>{label}</Label>
     </div>
   );
 };


### PR DESCRIPTION
## Purpose
There was a minor bug where the local preview was not properly being removed during the call.
There was a minor bug where the style was not being set for the default tile image if no stream is available

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[✔ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[✔ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Turned on a call with no video. Noticed the image was now being set because the width/height of the parent container is getting set. Then turned on and off the camera. The stream is properly turning off and on.

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->