### PR TITLE
Remove call retry, Show call reason screen on non-zero call reasons, show remote stream loading spinner

### DIFF
--- a/Calling/ClientApp/src/App.tsx
+++ b/Calling/ClientApp/src/App.tsx
@@ -89,7 +89,6 @@ const App = () => {
         />
       );
     } else if (page === 'unsupported') {
-      // page === 'error'
       window.document.title = 'Unsupported browser';
       return (
         <>

--- a/Calling/ClientApp/src/Utils/Utils.ts
+++ b/Calling/ClientApp/src/Utils/Utils.ts
@@ -11,9 +11,17 @@ export const utils = {
     return window.location.origin;
   },
   getTokenForUser: async (): Promise<CommunicationUserToken> => {
-    const response = await fetch('/userToken');
+    const response = await fetch('/token');
     if (response.ok) {
       return response.json();
+    }
+    throw new Error('Invalid token response');
+  },
+  getRefreshedTokenForUser: async (identity: string): Promise<string> => {
+    const response = await fetch(`/refreshToken/${identity}`)
+    if (response.ok) {
+      let content = await response.json();
+      return content.token;
     }
     throw new Error('Invalid token response');
   },

--- a/Calling/ClientApp/src/components/Configuration.tsx
+++ b/Calling/ClientApp/src/components/Configuration.tsx
@@ -10,7 +10,8 @@ import {
   AudioDeviceInfo,
   LocalVideoStream,
   DeviceManager,
-  CallAgent
+  CallAgent,
+  CallEndReason
 } from '@azure/communication-calling';
 import { VideoCameraEmphasisIcon } from '@fluentui/react-icons-northstar';
 import {
@@ -33,7 +34,7 @@ export interface ConfigurationScreenProps {
   setGroup(groupId: string): void;
   startCallHandler(): void;
   unsupportedStateHandler: () => void;
-  endCallHandler: () => void;
+  callEndedHandler: (reason: CallEndReason) => void;
   videoDeviceList: VideoDeviceInfo[];
   audioDeviceList: AudioDeviceInfo[];
   setVideoDeviceInfo(device: VideoDeviceInfo): void;

--- a/Calling/ClientApp/src/components/GroupCall.tsx
+++ b/Calling/ClientApp/src/components/GroupCall.tsx
@@ -52,28 +52,19 @@ export interface GroupCallProps {
   isGroup(): void;
   joinGroup(): void;
   endCallHandler(): void;
-  endCallTest(): void;
-  attempts: number;
-  setAttempts(attempts: number): void;
 }
 
 export default (props: GroupCallProps): JSX.Element => {
   const [selectedPane, setSelectedPane] = useState(CommandPanelTypes.None);
   const activeScreenShare = props.screenShareStreams && props.screenShareStreams.length === 1;
 
-  const { callAgent, call, groupId, joinGroup, attempts, setAttempts, endCallHandler } = props;
+  const { callAgent, call, joinGroup } = props;
 
   useEffect(() => {
-    if (attempts > 3) {
-      endCallHandler();
-      // after we switch the screen on the next tick we want to 
-      // set the attempts back to 0
-      setTimeout(()=> setAttempts(0), 0)
-    }
     if (callAgent && !call) {
       joinGroup();
     }
-  }, [callAgent, call, groupId, joinGroup, endCallHandler, attempts, setAttempts]);
+  }, [callAgent, call, joinGroup]);
 
   return (
     <Stack horizontalAlign="center" verticalAlign="center" styles={containerStyles}>

--- a/Calling/ClientApp/src/components/LocalStreamMedia.tsx
+++ b/Calling/ClientApp/src/components/LocalStreamMedia.tsx
@@ -23,7 +23,8 @@ export default (props: LocalStreamMediaProps): JSX.Element => {
     styles: {
       root: {
         width: '100%',
-        height: '100%'
+        height: '100%',
+        display: activeStreamBeingRendered ? 'none' : 'block'
       }
     }
   };
@@ -65,7 +66,7 @@ export default (props: LocalStreamMediaProps): JSX.Element => {
         className={localVideoContainerStyle}
         id={Constants.LOCAL_VIDEO_PREVIEW_ID}
       />
-      <Image {...imageProps} style={{display: activeStreamBeingRendered ? 'none' : 'block'}}/>
+      <Image {...imageProps}/>
       <Label className={videoHint}>{label}</Label>
     </div>
   );

--- a/Calling/ClientApp/src/components/RemoteStreamMedia.tsx
+++ b/Calling/ClientApp/src/components/RemoteStreamMedia.tsx
@@ -1,7 +1,7 @@
 // © Microsoft Corporation. All rights reserved.
 
 import React, { useEffect, useState } from 'react';
-import { Label } from '@fluentui/react';
+import { Label, Spinner, SpinnerSize } from '@fluentui/react';
 import { RemoteVideoStream, Renderer, RendererView } from '@azure/communication-calling';
 import { videoHint, mediaContainer } from './styles/StreamMedia.styles';
 import { utils } from 'Utils/Utils';
@@ -19,6 +19,7 @@ export default (props: RemoteStreamMediaProps): JSX.Element => {
   const streamId = props.stream ? utils.getStreamId(props.label, props.stream) : `${props.label} - no stream`;
 
   const [activeStreamBeingRendered, setActiveStreamBeingRendered] = useState(false);
+  const [showRenderLoading, setShowRenderLoading] = useState(false);
 
   const imageProps = {
     src: staticMediaSVG.toString(),
@@ -26,9 +27,17 @@ export default (props: RemoteStreamMediaProps): JSX.Element => {
     styles: {
       root: {
         width: '100%',
-        height: '100%'
+        height: '100%',
+        display: activeStreamBeingRendered ? 'none' : 'block'
       }
     }
+  };
+
+  const loadingStyle = {
+    height: '100%',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center'
   };
 
   const {label, stream} = props;
@@ -43,9 +52,11 @@ export default (props: RemoteStreamMediaProps): JSX.Element => {
 
       // set the flag that a stream is being rendered
       setActiveStreamBeingRendered(true);
+      setShowRenderLoading(true);
       const renderer: Renderer = new Renderer(props.stream);
       // this can block a really long time if we fail to be subscribed to the call and it has to retry
       const rendererView = await renderer.createView({ scalingMode: 'Crop' });
+      setShowRenderLoading(false);
       if (container && container.childElementCount === 0) {
         container.appendChild(rendererView.target);
       }
@@ -72,8 +83,10 @@ export default (props: RemoteStreamMediaProps): JSX.Element => {
 
   return (
     <div className={mediaContainer}>
-      <div style={{display: activeStreamBeingRendered ? 'block' : 'none' }} className={mediaContainer} id={streamId} />
-        <Image {...imageProps} style={{ display: activeStreamBeingRendered ? 'none' : 'block'}} />
+      <div style={{display: activeStreamBeingRendered ? 'block' : 'none' }} className={mediaContainer} id={streamId}>
+      { showRenderLoading && <Spinner style={loadingStyle} label={`Rendering stream...`} size={SpinnerSize.xSmall} />}
+      </div>
+        <Image {...imageProps}/>
         <Label className={videoHint}>{label}</Label>
     </div>
   );

--- a/Calling/ClientApp/src/containers/Configuration.ts
+++ b/Calling/ClientApp/src/containers/Configuration.ts
@@ -23,7 +23,7 @@ const mapStateToProps = (state: State, props: ConfigurationScreenProps) => ({
   microphonePermission: state.devices.microphonePermission
 });
 
-const mapDispatchToProps = (dispatch: any) => ({
+const mapDispatchToProps = (dispatch: any, props: ConfigurationScreenProps) => ({
   setLocalVideoStream: (localVideoStream: LocalVideoStream) => dispatch(setLocalVideoStream(localVideoStream)),
   setMic: (mic: boolean) => dispatch(setMic(mic)),
   setAudioDeviceInfo: (deviceInfo: AudioDeviceInfo) => dispatch(setAudioDeviceInfo(deviceInfo)),
@@ -31,7 +31,7 @@ const mapDispatchToProps = (dispatch: any) => ({
   setupCallClient: (unsupportedStateHandler: () => void) =>
     dispatch(initCallClient( unsupportedStateHandler)),
   setupCallAgent: (displayName: string) =>
-    dispatch(initCallAgent(displayName)),
+    dispatch(initCallAgent(displayName, props.callEndedHandler)),
   setGroup: (groupId: string) => dispatch(setGroup(groupId)),
   updateDevices: () => dispatch(updateDevices()),
 });

--- a/Calling/ClientApp/src/containers/GroupCall.ts
+++ b/Calling/ClientApp/src/containers/GroupCall.ts
@@ -9,7 +9,6 @@ import {
   LocalVideoStream
 } from '@azure/communication-calling';
 import { State } from '../core/reducers';
-import { callRetried } from 'core/actions/calls';
 
 const mapStateToProps = (state: State, props: GroupCallProps) => ({
   userId: state.sdk.userId,
@@ -47,8 +46,7 @@ const mapStateToProps = (state: State, props: GroupCallProps) => ({
   videoDeviceList: state.devices.videoDeviceList,
   audioDeviceList: state.devices.audioDeviceList,
   cameraPermission: state.devices.cameraPermission,
-  microphonePermission: state.devices.microphonePermission,
-  attempts: state.calls.attempts
+  microphonePermission: state.devices.microphonePermission
 });
 
 const mapDispatchToProps = (dispatch: any) => ({
@@ -59,8 +57,7 @@ const mapDispatchToProps = (dispatch: any) => ({
   setVideoDeviceInfo: (deviceInfo: VideoDeviceInfo) => {
     dispatch(setVideoDeviceInfo(deviceInfo));
   },
-  setLocalVideoStream: (localVideoStream: LocalVideoStream) => dispatch(setLocalVideoStream(localVideoStream)),
-  setAttempts: (attempts: number) => dispatch(callRetried(attempts)),
+  setLocalVideoStream: (localVideoStream: LocalVideoStream) => dispatch(setLocalVideoStream(localVideoStream))
 });
 
 const connector: any = connect(mapStateToProps, mapDispatchToProps);

--- a/Calling/ClientApp/src/core/actions/calls.ts
+++ b/Calling/ClientApp/src/core/actions/calls.ts
@@ -4,7 +4,6 @@ const SET_CALL_AGENT = 'SET_CALL_AGENT';
 const SET_GROUP = 'SET_GROUP';
 const CALL_ADDED = 'CALL_ADDED';
 const CALL_REMOVED = 'CALL_REMOVED';
-const CALL_RETRIED = 'CALL_RETRIED';
 const SET_CALL_STATE = 'SET_CALL_STATE';
 const SET_PARTICIPANTS = 'SET_PARTICIPANTS';
 
@@ -28,11 +27,6 @@ interface CallRemovedAction {
   call: Call | undefined;
   incomingCallEndReason: CallEndReason | undefined;
   groupCallEndReason: CallEndReason | undefined;
-}
-
-interface CallRetriedAction {
-  type: typeof CALL_RETRIED;
-  attempts: number;
 }
 
 interface SetCallStateAction {
@@ -89,21 +83,13 @@ export const setParticipants = (participants: RemoteParticipant[]): SetParticipa
   };
 };
 
-export const callRetried = (attempts: number): CallRetriedAction => {
-  return {
-    type: CALL_RETRIED,
-    attempts: attempts
-  };
-};
-
 export {
   SET_CALL_AGENT,
   SET_GROUP,
   CALL_ADDED,
   CALL_REMOVED,
   SET_CALL_STATE,
-  SET_PARTICIPANTS,
-  CALL_RETRIED
+  SET_PARTICIPANTS
 };
 
 export type CallTypes =
@@ -112,5 +98,4 @@ export type CallTypes =
   | SetCallStateAction
   | SetGroupAction
   | CallAddedAction
-  | CallRemovedAction
-  | CallRetriedAction;
+  | CallRemovedAction;

--- a/Calling/ClientApp/src/core/actions/sdk.ts
+++ b/Calling/ClientApp/src/core/actions/sdk.ts
@@ -1,6 +1,5 @@
 const SET_USERID = 'SET_USERID';
 const SET_DISPLAY_NAME = 'SET_DISPLAY_NAME';
-const SET_TOKEN = 'SET_TOKEN';
 
 interface SetUserIdAction {
   type: typeof SET_USERID;
@@ -10,11 +9,6 @@ interface SetUserIdAction {
 interface SetDisplayNameAction {
   type: typeof SET_DISPLAY_NAME;
   displayName: string;
-}
-
-interface SetTokenAction {
-  type: typeof SET_TOKEN;
-  token: string;
 }
 
 export const setUserId = (userId: string): SetUserIdAction => {
@@ -31,13 +25,6 @@ export const setDisplayName = (displayName: string): SetDisplayNameAction => {
   };
 };
 
-export const setToken = (token: string): SetTokenAction => {
-  return {
-    type: SET_TOKEN,
-    token
-  };
-};
+export { SET_USERID, SET_DISPLAY_NAME };
 
-export { SET_USERID, SET_DISPLAY_NAME, SET_TOKEN };
-
-export type SdkTypes = SetUserIdAction | SetDisplayNameAction | SetTokenAction;
+export type SdkTypes = SetUserIdAction | SetDisplayNameAction;

--- a/Calling/ClientApp/src/core/reducers/calls.ts
+++ b/Calling/ClientApp/src/core/reducers/calls.ts
@@ -7,8 +7,7 @@ import {
   SET_GROUP,
   SET_PARTICIPANTS,
   CallTypes,
-  SET_CALL_AGENT,
-  CALL_RETRIED
+  SET_CALL_AGENT
 } from '../actions/calls';
 
 export interface CallsState {
@@ -53,8 +52,6 @@ export const callsReducer: Reducer<CallsState, CallTypes> = (state = initialStat
       return { ...state, remoteParticipants: action.remoteParticipants };
     case SET_GROUP:
       return { ...state, group: action.group };
-    case CALL_RETRIED:
-      return { ...state, attempts: action.attempts };
     default:
       return state;
   }

--- a/Calling/ClientApp/src/core/reducers/sdk.ts
+++ b/Calling/ClientApp/src/core/reducers/sdk.ts
@@ -1,15 +1,13 @@
 import { Reducer } from 'redux';
-import { SET_USERID, SdkTypes, SET_DISPLAY_NAME, SET_TOKEN } from '../actions/sdk';
+import { SET_USERID, SdkTypes, SET_DISPLAY_NAME } from '../actions/sdk';
 
 export interface SdkState {
   userId?: string;
   displayName: string;
-  token: string;
 }
 
 const initialState: SdkState = {
-  displayName: '',
-  token: ''
+  displayName: ''
 };
 
 export const sdkReducer: Reducer<SdkState, SdkTypes> = (state = initialState, action: SdkTypes): SdkState => {
@@ -18,8 +16,6 @@ export const sdkReducer: Reducer<SdkState, SdkTypes> = (state = initialState, ac
       return { ...state, userId: action.userId };
     case SET_DISPLAY_NAME:
       return { ...state, displayName: action.displayName };
-    case SET_TOKEN:
-      return { ...state, token: action.token };
     default:
       return state;
   }

--- a/Calling/ClientApp/src/core/sideEffects.ts
+++ b/Calling/ClientApp/src/core/sideEffects.ts
@@ -219,9 +219,7 @@ export const initCallAgent = (name: string, callEndedHandler: (reason: CallEndRe
 
     const tokenResponse: CommunicationUserToken = await utils.getTokenForUser();
     const userToken = tokenResponse.token;
-    // necessary as the C# and JS types are different
-    const user = tokenResponse.user as any;
-    const userId = user.id;
+    const userId = tokenResponse.user.communicationUserId
     dispatch(setUserId(userId));
     
     const tokenCredential = new AzureCommunicationTokenCredential({

--- a/Calling/Controllers/UserTokenController.cs
+++ b/Calling/Controllers/UserTokenController.cs
@@ -34,9 +34,15 @@ namespace Calling
                 Response<(CommunicationUserIdentifier User, AccessToken Token)> response = await _client.CreateUserWithTokenAsync(scopes: new[] { CommunicationTokenScope.VoIP });
 
                 var responseValue = response.Value;
+
+                var jsonFormattedUser = new
+                {
+                    communicationUserId = responseValue.User.Id
+                };
+
                 var clientResponse = new
                 {
-                    user = responseValue.User,
+                    user = jsonFormattedUser,
                     token = responseValue.Token.Token,
                     expiresOn = responseValue.Token.ExpiresOn
                 };

--- a/Calling/Controllers/UserTokenController.cs
+++ b/Calling/Controllers/UserTokenController.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.Configuration;
 
 namespace Calling
 {
-    [Route("/userToken")]
     public class UserTokenController : Controller
     {
         private readonly CommunicationIdentityClient _client;
@@ -26,6 +25,7 @@ namespace Calling
         /// Gets a token to be used to initalize the call client
         /// </summary>
         /// <returns></returns>
+        [Route("/token")]
         [HttpGet]
         public async Task<IActionResult> GetAsync()
         {
@@ -41,6 +41,35 @@ namespace Calling
                     expiresOn = responseValue.Token.ExpiresOn
                 };
                 
+                return this.Ok(clientResponse);
+            }
+            catch (RequestFailedException ex)
+            {
+                Console.WriteLine($"Error occured while Generating Token: {ex}");
+                return this.Ok(this.Json(ex));
+            }
+        }
+
+        /// <summary>
+        /// Gets a token to be used to initalize the call client
+        /// </summary>
+        /// <returns></returns>
+        [Route("/refreshToken/{identity}")]
+        [HttpGet]
+        public async Task<IActionResult> GetAsync(string identity)
+        {
+            try
+            {
+                CommunicationUserIdentifier identifier = new CommunicationUserIdentifier(identity);
+                Response<AccessToken> response = await _client.IssueTokenAsync(identifier, scopes: new[] { CommunicationTokenScope.VoIP });
+
+                var responseValue = response.Value;
+                var clientResponse = new
+                {
+                    token = responseValue.Token,
+                    expiresOn = responseValue.ExpiresOn
+                };
+
                 return this.Ok(clientResponse);
             }
             catch (RequestFailedException ex)


### PR DESCRIPTION
## Purpose
Putting in some suggested fixes that we wanted to add into the calling hero sample.
+ Remove auto-retry when we were joining a call
+ When we do get removed from a call we will show the call reason and how to learn more about the code
+ Remote streams can take time to load so we are showing a spinner when its loading in

## Does this introduce a breaking change?
[ ] Yes
[❌ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[✔ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```