### PR TITLE
Introducing Remote streams selection/limit

### DIFF
--- a/Calling/ClientApp/package-lock.json
+++ b/Calling/ClientApp/package-lock.json
@@ -2352,6 +2352,140 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jest": {
+      "version": "26.0.22",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.22.tgz",
+      "integrity": "sha512-eeWwWjlqxvBxc4oQdkueW5OF/gtfSceKk4OnOAGlUSwS/liBRtZppbJuz1YkgbrbfGOoeBHun9fOvXnjNwrSOw==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^26.0.0",
+        "pretty-format": "^26.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-report": "*"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.13",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
+          "integrity": "sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
+          "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-diff": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.6.2.tgz",
+          "integrity": "sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^26.6.2",
+            "jest-get-type": "^26.3.0",
+            "pretty-format": "^26.6.2"
+          }
+        },
+        "jest-get-type": {
+          "version": "26.3.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+          "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.6.2",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^17.0.1"
+          }
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
@@ -3675,6 +3809,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bluebird": {
       "version": "3.7.2",
@@ -6645,6 +6788,12 @@
         "schema-utils": "^2.5.0"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filelist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.1.tgz",
@@ -8288,6 +8437,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         }
@@ -14351,6 +14501,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -14647,6 +14798,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/Calling/ClientApp/package.json
+++ b/Calling/ClientApp/package.json
@@ -37,6 +37,7 @@
     "y18n": ">=4.0.1"
   },
   "devDependencies": {
+    "@types/jest": "^26.0.22",
     "ajv": "^6.9.1",
     "cross-env": "^5.2.0",
     "eslint": "^6.8.0",

--- a/Calling/ClientApp/src/components/MediaGallery.tsx
+++ b/Calling/ClientApp/src/components/MediaGallery.tsx
@@ -11,7 +11,7 @@ export interface MediaGalleryProps {
   displayName: string;
   remoteParticipants: RemoteParticipant[];
   localVideoStream: LocalVideoStream;
-  selectedParticipants: SelectionState[];
+  dominantParticipants: SelectionState[];
 }
 
 export default (props: MediaGalleryProps): JSX.Element => {
@@ -28,11 +28,11 @@ export default (props: MediaGalleryProps): JSX.Element => {
   );
   const getMediaGalleryTilesForParticipants = (participants: RemoteParticipant[], userId: string, displayName: string) => {
     const remoteParticipantsMediaGalleryItems = participants.map((participant) => (
-       <div key={`${utils.getId(participant.identifier)}-tile`} className={mediaGalleryStyle}>
+      <div key={`${utils.getId(participant.identifier)}-tile`} className={mediaGalleryStyle}>
         <RemoteStreamMedia
           key={utils.getId(participant.identifier)}
           stream={participant.videoStreams[0]}
-          isParticipantStreamSelected= {props.selectedParticipants.filter(p => p.participantId === utils.getId(participant.identifier)).length > 0}
+          isParticipantStreamSelected = {props.dominantParticipants.filter(p => p.participantId === utils.getId(participant.identifier)).length > 0}
           label={participant.displayName ?? utils.getId(participant.identifier)}
         />
       </div>

--- a/Calling/ClientApp/src/components/MediaGallery.tsx
+++ b/Calling/ClientApp/src/components/MediaGallery.tsx
@@ -4,12 +4,14 @@ import { RemoteParticipant, LocalVideoStream } from '@azure/communication-callin
 import { utils } from '../Utils/Utils';
 import LocalStreamMedia from './LocalStreamMedia';
 import RemoteStreamMedia from './RemoteStreamMedia';
+import { SelectionState } from 'core/RemoteStreamSelector';
 
 export interface MediaGalleryProps {
   userId: string;
   displayName: string;
   remoteParticipants: RemoteParticipant[];
   localVideoStream: LocalVideoStream;
+  selectedParticipants: SelectionState[];
 }
 
 export default (props: MediaGalleryProps): JSX.Element => {
@@ -26,10 +28,11 @@ export default (props: MediaGalleryProps): JSX.Element => {
   );
   const getMediaGalleryTilesForParticipants = (participants: RemoteParticipant[], userId: string, displayName: string) => {
     const remoteParticipantsMediaGalleryItems = participants.map((participant) => (
-      <div key={`${utils.getId(participant.identifier)}-tile`} className={mediaGalleryStyle}>
+       <div key={`${utils.getId(participant.identifier)}-tile`} className={mediaGalleryStyle}>
         <RemoteStreamMedia
           key={utils.getId(participant.identifier)}
           stream={participant.videoStreams[0]}
+          isParticipantStreamSelected= {props.selectedParticipants.filter(p => p.participantId === utils.getId(participant.identifier)).length > 0}
           label={participant.displayName ?? utils.getId(participant.identifier)}
         />
       </div>

--- a/Calling/ClientApp/src/components/RemoteStreamMedia.tsx
+++ b/Calling/ClientApp/src/components/RemoteStreamMedia.tsx
@@ -11,6 +11,7 @@ import { Image, ImageFit } from '@fluentui/react';
 export interface RemoteStreamMediaProps {
   label: string;
   stream: RemoteVideoStream | undefined;
+  isParticipantStreamSelected: boolean;
 }
 
 export default (props: RemoteStreamMediaProps): JSX.Element => {
@@ -44,7 +45,7 @@ export default (props: RemoteStreamMediaProps): JSX.Element => {
 
   const renderRemoteStream = async () => {
     const container = document.getElementById(streamId);
-    if (container && props.stream && props.stream.isAvailable) {
+    if (container && props.stream && props.stream.isAvailable && props.isParticipantStreamSelected) {
       // if we are already rendering a stream we don't want to start rendering the same stream
       if (activeStreamBeingRendered) {
         return;

--- a/Calling/ClientApp/src/components/RemoteStreamMedia.tsx
+++ b/Calling/ClientApp/src/components/RemoteStreamMedia.tsx
@@ -1,6 +1,6 @@
 // © Microsoft Corporation. All rights reserved.
 
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Label, Spinner, SpinnerSize } from '@fluentui/react';
 import { RemoteVideoStream, VideoStreamRenderer, VideoStreamRendererView } from '@azure/communication-calling';
 import { videoHint, mediaContainer } from './styles/StreamMedia.styles';
@@ -41,11 +41,11 @@ export default (props: RemoteStreamMediaProps): JSX.Element => {
     alignItems: 'center'
   };
 
-  const {label, stream} = props;
+  const {label, stream, isParticipantStreamSelected} = props;
 
-  const renderRemoteStream = async () => {
+  const renderRemoteStream = useCallback(async () => {
     const container = document.getElementById(streamId);
-    if (container && props.stream && props.stream.isAvailable && props.isParticipantStreamSelected) {
+    if (container && stream && stream.isAvailable && isParticipantStreamSelected) {
       // if we are already rendering a stream we don't want to start rendering the same stream
       if (activeStreamBeingRendered) {
         return;
@@ -54,7 +54,7 @@ export default (props: RemoteStreamMediaProps): JSX.Element => {
       // set the flag that a stream is being rendered
       setActiveStreamBeingRendered(true);
       setShowRenderLoading(true);
-      const renderer: VideoStreamRenderer = new VideoStreamRenderer(props.stream);
+      const renderer: VideoStreamRenderer = new VideoStreamRenderer(stream);
       // this can block a really long time if we fail to be subscribed to the call and it has to retry
       const rendererView = await renderer.createView({ scalingMode: 'Crop' });
       setShowRenderLoading(false);
@@ -68,7 +68,7 @@ export default (props: RemoteStreamMediaProps): JSX.Element => {
         rendererView.dispose();
       }
     }
-  };
+  }, [stream, isParticipantStreamSelected, setShowRenderLoading, setActiveStreamBeingRendered]);
 
   useEffect(() => {
     if (!stream) {
@@ -80,7 +80,7 @@ export default (props: RemoteStreamMediaProps): JSX.Element => {
     if (stream.isAvailable) {
       renderRemoteStream();
     }
-  }, [stream, renderRemoteStream]);
+  }, [stream, isParticipantStreamSelected, renderRemoteStream]);
 
   return (
     <div className={mediaContainer}>

--- a/Calling/ClientApp/src/containers/MediaGallery.ts
+++ b/Calling/ClientApp/src/containers/MediaGallery.ts
@@ -6,7 +6,7 @@ const mapStateToProps = (state: State) => ({
   userId: state.sdk.userId,
   displayName: state.calls.callAgent?.displayName,
   remoteParticipants: state.calls.remoteParticipants,
-  selectedParticipants: state.calls.selectedParticipants,
+  dominantParticipants: state.calls.dominantParticipants,
   localVideoStream: state.streams.localVideoStream
 });
 

--- a/Calling/ClientApp/src/containers/MediaGallery.ts
+++ b/Calling/ClientApp/src/containers/MediaGallery.ts
@@ -6,6 +6,7 @@ const mapStateToProps = (state: State) => ({
   userId: state.sdk.userId,
   displayName: state.calls.callAgent?.displayName,
   remoteParticipants: state.calls.remoteParticipants,
+  selectedParticipants: state.calls.selectedParticipants,
   localVideoStream: state.streams.localVideoStream
 });
 

--- a/Calling/ClientApp/src/core/RemoteStreamSelector.test.ts
+++ b/Calling/ClientApp/src/core/RemoteStreamSelector.test.ts
@@ -1,0 +1,80 @@
+import RemoteStreamSelector from './RemoteStreamSelector';
+
+let remoteStreamSelector: RemoteStreamSelector;
+let mockStartTimeInMilliseconds = 1000000000000;
+
+const mockDispatch = jest.fn((action) => action.dominantParticipants[0].displayName);
+Date.now = jest.fn(() => mockStartTimeInMilliseconds++);
+console.log = jest.fn();
+
+beforeAll(() => {
+  remoteStreamSelector = RemoteStreamSelector.getInstance(mockDispatch as any);
+  remoteStreamSelector.participantStateChanged('1', 'user1', 'Connected', false, false);
+  remoteStreamSelector.participantStateChanged('2', 'user2', 'Connected', false, false);
+  remoteStreamSelector.participantStateChanged('3', 'user3', 'Connected', false, false);
+  remoteStreamSelector.processCommands();
+});
+
+test('For non-video participants, precedence to the unmuted', async () => {
+  remoteStreamSelector.participantAudioChanged('2', true);
+  remoteStreamSelector.processCommands();
+
+  expect(mockDispatch).toReturnWith('user2');
+});
+
+test('For non-video participants, precedence to participants who have unmuted the latest', async () => {
+  remoteStreamSelector.participantAudioChanged('1', true);
+  remoteStreamSelector.participantAudioChanged('2', true);
+  remoteStreamSelector.participantAudioChanged('3', true);
+  remoteStreamSelector.processCommands();
+
+  expect(mockDispatch).toReturnWith('user3');
+});
+
+test('For non-video participants, if latest unmuted participant have muted themselves later, precedence is updated to second latest unmuted', () => {
+  remoteStreamSelector.participantAudioChanged('1', true);
+  remoteStreamSelector.participantAudioChanged('2', true);
+  remoteStreamSelector.participantAudioChanged('2', false);
+  remoteStreamSelector.processCommands();
+
+  expect(mockDispatch).toReturnWith('user1');
+});
+
+test('Video participants should take the top precedence, even if muted.', () => {
+  remoteStreamSelector.participantAudioChanged('1', true);
+  remoteStreamSelector.participantAudioChanged('2', true);
+  remoteStreamSelector.participantVideoChanged('3', true);
+  remoteStreamSelector.processCommands();
+
+  expect(mockDispatch).toReturnWith('user3');
+});
+
+test('For video participants, precedence to unmuted participants', () => {
+  remoteStreamSelector.participantVideoChanged('1', true);
+  remoteStreamSelector.participantVideoChanged('2', true);
+  remoteStreamSelector.participantAudioChanged('2', true);
+  remoteStreamSelector.participantVideoChanged('3', true);
+  remoteStreamSelector.processCommands();
+
+  expect(mockDispatch).toReturnWith('user2');
+});
+
+test('For video participants, if all participants are either muted or unmuted, priority to the first participant who turned on thier camera', () => {
+  remoteStreamSelector.participantVideoChanged('1', true);
+  remoteStreamSelector.participantVideoChanged('2', true);
+  remoteStreamSelector.participantVideoChanged('3', true);
+  remoteStreamSelector.processCommands();
+
+  expect(mockDispatch).toReturnWith('user1');
+});
+
+// Reset all participants to default video off & muted.
+afterEach(() => {
+  remoteStreamSelector.participantVideoChanged('1', false);
+  remoteStreamSelector.participantVideoChanged('2', false);
+  remoteStreamSelector.participantVideoChanged('3', false);
+  remoteStreamSelector.participantAudioChanged('1', false);
+  remoteStreamSelector.participantAudioChanged('2', false);
+  remoteStreamSelector.participantAudioChanged('3', false);
+  remoteStreamSelector.processCommands();
+});

--- a/Calling/ClientApp/src/core/RemoteStreamSelector.test.ts
+++ b/Calling/ClientApp/src/core/RemoteStreamSelector.test.ts
@@ -8,7 +8,7 @@ Date.now = jest.fn(() => mockStartTimeInMilliseconds++);
 console.log = jest.fn();
 
 beforeAll(() => {
-  remoteStreamSelector = RemoteStreamSelector.getInstance(mockDispatch as any);
+  remoteStreamSelector = RemoteStreamSelector.getInstance(1, mockDispatch as any);
   remoteStreamSelector.participantStateChanged('1', 'user1', 'Connected', false, false);
   remoteStreamSelector.participantStateChanged('2', 'user2', 'Connected', false, false);
   remoteStreamSelector.participantStateChanged('3', 'user3', 'Connected', false, false);
@@ -59,18 +59,19 @@ test('For video participants, precedence to unmuted participants', () => {
   expect(mockDispatch).toReturnWith('user2');
 });
 
-test('For video participants, if all participants are muted, priority to the first participant who turned on thier camera', () => {
+test('For video participants, if all participants are unmuted, precedence to participants who have unmuted the latest', () => {
   remoteStreamSelector.participantVideoChanged('1', true);
   remoteStreamSelector.participantVideoChanged('2', true);
   remoteStreamSelector.participantAudioChanged('2', true);
   remoteStreamSelector.participantVideoChanged('3', true);
+  remoteStreamSelector.participantAudioChanged('3', true);
   remoteStreamSelector.participantAudioChanged('1', true);
   remoteStreamSelector.processCommands();
 
   expect(mockDispatch).toReturnWith('user1');
 });
 
-test('For video participants, if all participants are unmuted, precedence to participants who have unmuted the latest', () => {
+test('For video participants, if all participants are muted, priority to the first participant who turned on thier camera', () => {
   remoteStreamSelector.participantVideoChanged('1', true);
   remoteStreamSelector.participantVideoChanged('2', true);
   remoteStreamSelector.participantVideoChanged('3', true);

--- a/Calling/ClientApp/src/core/RemoteStreamSelector.test.ts
+++ b/Calling/ClientApp/src/core/RemoteStreamSelector.test.ts
@@ -40,7 +40,7 @@ test('For non-video participants, if latest unmuted participant have muted thems
   expect(mockDispatch).toReturnWith('user1');
 });
 
-test('Video participants should take the top precedence, even if muted.', () => {
+test('Video participants should take the top precedence, even if muted and others unmuted.', () => {
   remoteStreamSelector.participantAudioChanged('1', true);
   remoteStreamSelector.participantAudioChanged('2', true);
   remoteStreamSelector.participantVideoChanged('3', true);

--- a/Calling/ClientApp/src/core/RemoteStreamSelector.test.ts
+++ b/Calling/ClientApp/src/core/RemoteStreamSelector.test.ts
@@ -15,14 +15,14 @@ beforeAll(() => {
   remoteStreamSelector.processCommands();
 });
 
-test('For non-video participants, precedence to the unmuted', async () => {
+test('For non-video participants, precedence to the unmuted', () => {
   remoteStreamSelector.participantAudioChanged('2', true);
   remoteStreamSelector.processCommands();
 
   expect(mockDispatch).toReturnWith('user2');
 });
 
-test('For non-video participants, precedence to participants who have unmuted the latest', async () => {
+test('For non-video participants, precedence to participants who have unmuted the latest', () => {
   remoteStreamSelector.participantAudioChanged('1', true);
   remoteStreamSelector.participantAudioChanged('2', true);
   remoteStreamSelector.participantAudioChanged('3', true);
@@ -59,7 +59,18 @@ test('For video participants, precedence to unmuted participants', () => {
   expect(mockDispatch).toReturnWith('user2');
 });
 
-test('For video participants, if all participants are either muted or unmuted, priority to the first participant who turned on thier camera', () => {
+test('For video participants, if all participants are muted, priority to the first participant who turned on thier camera', () => {
+  remoteStreamSelector.participantVideoChanged('1', true);
+  remoteStreamSelector.participantVideoChanged('2', true);
+  remoteStreamSelector.participantAudioChanged('2', true);
+  remoteStreamSelector.participantVideoChanged('3', true);
+  remoteStreamSelector.participantAudioChanged('1', true);
+  remoteStreamSelector.processCommands();
+
+  expect(mockDispatch).toReturnWith('user1');
+});
+
+test('For video participants, if all participants are unmuted, precedence to participants who have unmuted the latest', () => {
   remoteStreamSelector.participantVideoChanged('1', true);
   remoteStreamSelector.participantVideoChanged('2', true);
   remoteStreamSelector.participantVideoChanged('3', true);

--- a/Calling/ClientApp/src/core/RemoteStreamSelector.ts
+++ b/Calling/ClientApp/src/core/RemoteStreamSelector.ts
@@ -1,4 +1,4 @@
-import { setSelectedParticipants } from './actions/calls';
+import { setDominantParticipants } from './actions/calls';
 import { Dispatch } from "redux";
 import { RemoteParticipantState } from '@azure/communication-calling';
 
@@ -60,7 +60,7 @@ export class SelectionState {
 }
 
 export default class RemoteStreamSelector {
-  private static SelectedParticipantsCount = 1;
+  private static DominantParticipantsCount = 1;
   private static ProcessingDelayInSeconds = 2000;
   private readonly dipatch: Dispatch;
   private batchedCommands: Event[];
@@ -99,7 +99,7 @@ export default class RemoteStreamSelector {
     let sortedList = [...this.remoteParticipants.values()].sort(this.compareFn);
     console.log("RemoteStreamSelector: Participants sorted list", sortedList);
 
-    this.dipatch(setSelectedParticipants(sortedList.slice(0, RemoteStreamSelector.SelectedParticipantsCount)));
+    this.dipatch(setDominantParticipants(sortedList.slice(0, RemoteStreamSelector.DominantParticipantsCount)));
   }
 
   public participantAudioChanged = (participantId: string, isUnmuted: boolean): void => {
@@ -118,10 +118,11 @@ export default class RemoteStreamSelector {
       case 'Connected':
         this.remoteParticipants.set(participantId, new SelectionState(participantId, displayName, isUnMuted, isVideoOn));
         this.participantAudioChanged(participantId, isUnMuted);
-        this.participantVideoChanged(participantId, isVideoOn)
+        this.participantVideoChanged(participantId, isVideoOn);
         break;
       case 'Disconnected':
         this.remoteParticipants.delete(participantId);
+        this.processCommands(); // Force update Redux list with removed participant.
         break;
     }
   }

--- a/Calling/ClientApp/src/core/RemoteStreamSelector.ts
+++ b/Calling/ClientApp/src/core/RemoteStreamSelector.ts
@@ -1,0 +1,132 @@
+import { setSelectedParticipants } from './actions/calls';
+import { Dispatch } from "redux";
+import { RemoteParticipantState } from '@azure/communication-calling';
+
+interface Event {
+  participantId: string;
+  timeStamp: number;
+  process: Function;
+}
+
+class AudioChangedEvent implements Event {
+  participantId: string;
+  timeStamp: number;
+  isUnMuted: boolean = false;
+
+  constructor(participantId: string, isUnMuted: boolean){
+    this.participantId = participantId;
+    this.isUnMuted = isUnMuted;
+    this.timeStamp = Date.now();
+  }
+
+  process(participant: SelectionState): void {
+    if(this.isUnMuted  && !participant.isUnMuted){
+      participant.lastUnMuted = this.timeStamp;
+    }
+    participant.isUnMuted = this.isUnMuted;
+  }
+}
+
+class VideoChangedEvent implements Event {
+  participantId: string;
+  timeStamp: number;
+  isVideoOn: boolean = false;
+
+  constructor(participantId: string, isVideoOn: boolean){
+    this.participantId = participantId;
+    this.isVideoOn = isVideoOn;
+    this.timeStamp = Date.now();
+  }
+
+  process(participant: SelectionState): void {
+    participant.isVideoOn = this.isVideoOn;
+  }
+}
+
+export class SelectionState {
+  isVideoOn: boolean;
+  isUnMuted: boolean;
+  lastUnMuted: number;
+  participantId: string;
+  displayName: string;
+
+  constructor(participantId: string, displayName: string, isUnMuted: boolean = false, isVideoOn: boolean = false){
+    this.participantId = participantId;
+    this.displayName = displayName;
+    this.isUnMuted = isUnMuted;
+    this.isVideoOn = isVideoOn;
+    this.lastUnMuted = -1;
+  }
+}
+
+export default class RemoteStreamSelector {
+  private static SelectedParticipantsCount = 1;
+  private static ProcessingDelayInSeconds = 2000;
+  private readonly dipatch: Dispatch;
+  private batchedCommands: Event[];
+  private remoteParticipants: Map<string, SelectionState>;
+  static Singleton: RemoteStreamSelector;
+
+  constructor(dispatch: Dispatch) {
+    this.dipatch = dispatch;
+    this.batchedCommands = [];
+    this.remoteParticipants = new Map();
+
+    setInterval(() => this.batchedCommands.length > 0 && this.processCommands(), RemoteStreamSelector.ProcessingDelayInSeconds);
+  }
+
+  compareFn = (a: SelectionState, b: SelectionState) => {
+    if(a.isVideoOn === b.isVideoOn){
+      if(a.isUnMuted === b.isUnMuted)
+        return b.lastUnMuted - a.lastUnMuted;
+      return a.isUnMuted ? -1 : 1
+    }
+    return a.isVideoOn ? -1 : 1;
+  };
+
+  processCommands = (commands = this.batchedCommands): void => {
+    commands.forEach(command => {
+      let participant = this.remoteParticipants.get(command.participantId);
+      if(!participant){
+        console.error(`RemoteStreamSelector: Participant ${command.participantId} not found`);
+        return;
+      }
+      command.process(participant);
+    });
+    this.batchedCommands = [];
+    console.log("RemoteStreamSelector: Remote participants", this.remoteParticipants);
+    
+    let sortedList = [...this.remoteParticipants.values()].sort(this.compareFn);
+    console.log("RemoteStreamSelector: Participants sorted list", sortedList);
+
+    this.dipatch(setSelectedParticipants(sortedList.slice(0, RemoteStreamSelector.SelectedParticipantsCount)));
+  }
+
+  public participantAudioChanged = (participantId: string, isUnmuted: boolean): void => {
+    this.batchedCommands.push(new AudioChangedEvent(participantId, isUnmuted));
+  }
+
+  public participantVideoChanged = (participantId: string, isVideoOn: boolean): void => {
+    this.batchedCommands.push(new VideoChangedEvent(participantId, isVideoOn));
+  }
+
+  public participantStateChanged = (participantId: string, displayName: string, state: RemoteParticipantState, isUnMuted: boolean, isVideoOn: boolean): void => {
+    switch(state){
+      case 'Connecting':
+        this.remoteParticipants.set(participantId, new SelectionState(participantId, displayName, isUnMuted, isVideoOn));
+        break;
+      case 'Connected':
+        this.remoteParticipants.set(participantId, new SelectionState(participantId, displayName, isUnMuted, isVideoOn));
+        this.participantAudioChanged(participantId, isUnMuted);
+        this.participantVideoChanged(participantId, isVideoOn)
+        break;
+      case 'Disconnected':
+        this.remoteParticipants.delete(participantId);
+        break;
+    }
+  }
+
+  public static getInstance = (dispatch: Dispatch): RemoteStreamSelector => (
+    RemoteStreamSelector.Singleton = RemoteStreamSelector.Singleton ?? new RemoteStreamSelector(dispatch)
+  )
+}

--- a/Calling/ClientApp/src/core/actions/calls.ts
+++ b/Calling/ClientApp/src/core/actions/calls.ts
@@ -1,4 +1,5 @@
 import { CallEndReason, Call, RemoteParticipant, CallAgent } from '@azure/communication-calling';
+import { SelectionState } from '../RemoteStreamSelector';
 
 const SET_CALL_AGENT = 'SET_CALL_AGENT';
 const SET_GROUP = 'SET_GROUP';
@@ -6,6 +7,7 @@ const CALL_ADDED = 'CALL_ADDED';
 const CALL_REMOVED = 'CALL_REMOVED';
 const SET_CALL_STATE = 'SET_CALL_STATE';
 const SET_PARTICIPANTS = 'SET_PARTICIPANTS';
+const SET_SELECTED_PARTICIPANTS = 'SET_SELECTED_PARTICIPANTS';
 
 interface SetCallAgentAction {
   type: typeof SET_CALL_AGENT;
@@ -37,6 +39,11 @@ interface SetCallStateAction {
 interface SetParticipantsAction {
   type: typeof SET_PARTICIPANTS;
   remoteParticipants: RemoteParticipant[];
+}
+
+interface SetSelectedParticipantsAction {
+  type: typeof SET_SELECTED_PARTICIPANTS;
+  selectedParticipants: SelectionState[];
 }
 
 export const setCallAgent = (callAgent: CallAgent): SetCallAgentAction => {
@@ -83,18 +90,27 @@ export const setParticipants = (participants: RemoteParticipant[]): SetParticipa
   };
 };
 
+export const setSelectedParticipants = (selected: SelectionState[]): SetSelectedParticipantsAction => {
+  return {
+    type: SET_SELECTED_PARTICIPANTS,
+    selectedParticipants: selected
+  };
+};
+
 export {
   SET_CALL_AGENT,
   SET_GROUP,
   CALL_ADDED,
   CALL_REMOVED,
   SET_CALL_STATE,
+  SET_SELECTED_PARTICIPANTS,
   SET_PARTICIPANTS
 };
 
 export type CallTypes =
   | SetCallAgentAction
   | SetParticipantsAction
+  | SetSelectedParticipantsAction
   | SetCallStateAction
   | SetGroupAction
   | CallAddedAction

--- a/Calling/ClientApp/src/core/actions/calls.ts
+++ b/Calling/ClientApp/src/core/actions/calls.ts
@@ -7,7 +7,7 @@ const CALL_ADDED = 'CALL_ADDED';
 const CALL_REMOVED = 'CALL_REMOVED';
 const SET_CALL_STATE = 'SET_CALL_STATE';
 const SET_PARTICIPANTS = 'SET_PARTICIPANTS';
-const SET_SELECTED_PARTICIPANTS = 'SET_SELECTED_PARTICIPANTS';
+const SET_DOMINANT_PARTICIPANTS = 'SET_DOMINANT_PARTICIPANTS';
 
 interface SetCallAgentAction {
   type: typeof SET_CALL_AGENT;
@@ -41,9 +41,9 @@ interface SetParticipantsAction {
   remoteParticipants: RemoteParticipant[];
 }
 
-interface SetSelectedParticipantsAction {
-  type: typeof SET_SELECTED_PARTICIPANTS;
-  selectedParticipants: SelectionState[];
+interface SetDominantParticipantsAction {
+  type: typeof SET_DOMINANT_PARTICIPANTS;
+  dominantParticipants: SelectionState[];
 }
 
 export const setCallAgent = (callAgent: CallAgent): SetCallAgentAction => {
@@ -90,10 +90,10 @@ export const setParticipants = (participants: RemoteParticipant[]): SetParticipa
   };
 };
 
-export const setSelectedParticipants = (selected: SelectionState[]): SetSelectedParticipantsAction => {
+export const setDominantParticipants = (selected: SelectionState[]): SetDominantParticipantsAction => {
   return {
-    type: SET_SELECTED_PARTICIPANTS,
-    selectedParticipants: selected
+    type: SET_DOMINANT_PARTICIPANTS,
+    dominantParticipants: selected
   };
 };
 
@@ -103,14 +103,14 @@ export {
   CALL_ADDED,
   CALL_REMOVED,
   SET_CALL_STATE,
-  SET_SELECTED_PARTICIPANTS,
+  SET_DOMINANT_PARTICIPANTS,
   SET_PARTICIPANTS
 };
 
 export type CallTypes =
   | SetCallAgentAction
   | SetParticipantsAction
-  | SetSelectedParticipantsAction
+  | SetDominantParticipantsAction
   | SetCallStateAction
   | SetGroupAction
   | CallAddedAction

--- a/Calling/ClientApp/src/core/constants.ts
+++ b/Calling/ClientApp/src/core/constants.ts
@@ -8,4 +8,5 @@ export class Constants {
   static CONFIGURATION_LOCAL_VIDEO_PREVIEW_ID = 'ConfigurationLocalVideoPreview';
   static LOCAL_VIDEO_PREVIEW_ID = 'LocalVideoPreview';
   static MINI_HEADER_WINDOW_WIDTH = 360;
+  static DOMINTANT_PARTICIPANTS_COUNT = 1;
 }

--- a/Calling/ClientApp/src/core/reducers/calls.ts
+++ b/Calling/ClientApp/src/core/reducers/calls.ts
@@ -1,10 +1,12 @@
 import { Call, CallEndReason, RemoteParticipant, CallAgent } from '@azure/communication-calling';
+import { SelectionState } from 'core/RemoteStreamSelector';
 import { Reducer } from 'redux';
 import {
   CALL_ADDED,
   CALL_REMOVED,
   SET_CALL_STATE,
   SET_GROUP,
+  SET_SELECTED_PARTICIPANTS,
   SET_PARTICIPANTS,
   CallTypes,
   SET_CALL_AGENT
@@ -19,6 +21,7 @@ export interface CallsState {
   groupCallEndReason: CallEndReason | undefined;
   remoteParticipants: RemoteParticipant[];
   attempts: number;
+  selectedParticipants: SelectionState[];
 }
 
 const initialState: CallsState = {
@@ -28,6 +31,7 @@ const initialState: CallsState = {
   incomingCallEndReason: undefined,
   groupCallEndReason: undefined,
   remoteParticipants: [],
+  selectedParticipants: [],
   group: '',
   attempts: 0
 };
@@ -48,6 +52,8 @@ export const callsReducer: Reducer<CallsState, CallTypes> = (state = initialStat
       };
     case SET_CALL_STATE:
       return { ...state, callState: action.callState };
+    case SET_SELECTED_PARTICIPANTS:
+      return {...state, selectedParticipants: action.selectedParticipants};
     case SET_PARTICIPANTS:
       return { ...state, remoteParticipants: action.remoteParticipants };
     case SET_GROUP:

--- a/Calling/ClientApp/src/core/reducers/calls.ts
+++ b/Calling/ClientApp/src/core/reducers/calls.ts
@@ -53,7 +53,7 @@ export const callsReducer: Reducer<CallsState, CallTypes> = (state = initialStat
     case SET_CALL_STATE:
       return { ...state, callState: action.callState };
     case SET_DOMINANT_PARTICIPANTS:
-      return {...state, dominantParticipants: action.dominantParticipants};
+      return { ...state, dominantParticipants: action.dominantParticipants };
     case SET_PARTICIPANTS:
       return { ...state, remoteParticipants: action.remoteParticipants };
     case SET_GROUP:

--- a/Calling/ClientApp/src/core/reducers/calls.ts
+++ b/Calling/ClientApp/src/core/reducers/calls.ts
@@ -6,7 +6,7 @@ import {
   CALL_REMOVED,
   SET_CALL_STATE,
   SET_GROUP,
-  SET_SELECTED_PARTICIPANTS,
+  SET_DOMINANT_PARTICIPANTS,
   SET_PARTICIPANTS,
   CallTypes,
   SET_CALL_AGENT
@@ -21,7 +21,7 @@ export interface CallsState {
   groupCallEndReason: CallEndReason | undefined;
   remoteParticipants: RemoteParticipant[];
   attempts: number;
-  selectedParticipants: SelectionState[];
+  dominantParticipants: SelectionState[];
 }
 
 const initialState: CallsState = {
@@ -31,7 +31,7 @@ const initialState: CallsState = {
   incomingCallEndReason: undefined,
   groupCallEndReason: undefined,
   remoteParticipants: [],
-  selectedParticipants: [],
+  dominantParticipants: [],
   group: '',
   attempts: 0
 };
@@ -52,8 +52,8 @@ export const callsReducer: Reducer<CallsState, CallTypes> = (state = initialStat
       };
     case SET_CALL_STATE:
       return { ...state, callState: action.callState };
-    case SET_SELECTED_PARTICIPANTS:
-      return {...state, selectedParticipants: action.selectedParticipants};
+    case SET_DOMINANT_PARTICIPANTS:
+      return {...state, dominantParticipants: action.dominantParticipants};
     case SET_PARTICIPANTS:
       return { ...state, remoteParticipants: action.remoteParticipants };
     case SET_GROUP:

--- a/Calling/ClientApp/src/core/reducers/streams.ts
+++ b/Calling/ClientApp/src/core/reducers/streams.ts
@@ -10,7 +10,6 @@ import {
 import { DeviceTypes, SET_VIDEO_DEVICE_INFO } from '../actions/devices';
 
 export interface StreamsState {
-  streams: ParticipantStream[];
   screenShareStreams: ParticipantStream[];
   localVideoRendererIsBusy: boolean;
   localVideoStream?: LocalVideoStream;
@@ -19,7 +18,6 @@ export interface StreamsState {
 const initialState: StreamsState = {
   localVideoRendererIsBusy: false,
   localVideoStream: undefined,
-  streams: [],
   screenShareStreams: []
 };
 
@@ -35,7 +33,7 @@ export const streamsReducer: Reducer<StreamsState, StreamTypes | DeviceTypes> = 
       return state;
     case SET_LOCAL_VIDEO_STREAM:
       return { ...state, localVideoStream: action.localVideoStream };
-    case ADD_SCREENSHARE_STREAM:
+      case ADD_SCREENSHARE_STREAM:
       const newScreenShareStream: ParticipantStream = { stream: action.stream, user: action.user };
       return { ...state, screenShareStreams: [...state.screenShareStreams, newScreenShareStream] };
     case REMOVE_SCREENSHARE_STREAM:

--- a/Calling/ClientApp/src/core/reducers/streams.ts
+++ b/Calling/ClientApp/src/core/reducers/streams.ts
@@ -33,7 +33,7 @@ export const streamsReducer: Reducer<StreamsState, StreamTypes | DeviceTypes> = 
       return state;
     case SET_LOCAL_VIDEO_STREAM:
       return { ...state, localVideoStream: action.localVideoStream };
-      case ADD_SCREENSHARE_STREAM:
+    case ADD_SCREENSHARE_STREAM:
       const newScreenShareStream: ParticipantStream = { stream: action.stream, user: action.user };
       return { ...state, screenShareStreams: [...state.screenShareStreams, newScreenShareStream] };
     case REMOVE_SCREENSHARE_STREAM:

--- a/Calling/ClientApp/src/core/sideEffects.ts
+++ b/Calling/ClientApp/src/core/sideEffects.ts
@@ -36,6 +36,7 @@ import { addScreenShareStream, removeScreenShareStream } from './actions/streams
 import { State } from './reducers';
 import { setLogLevel } from '@azure/logger';
 import RemoteStreamSelector from './RemoteStreamSelector';
+import { Constants } from './constants';
 
 export const setMicrophone = (mic: boolean) => {
   return async (dispatch: Dispatch, getState: () => State): Promise<void> => {
@@ -88,7 +89,7 @@ const subscribeToParticipant = (
   call: Call,
   dispatch: Dispatch
 ): void => {
-  let remoteStreamSelector = RemoteStreamSelector.getInstance(1, dispatch);
+  let remoteStreamSelector = RemoteStreamSelector.getInstance(Constants.DOMINTANT_PARTICIPANTS_COUNT, dispatch);
 
   participant.on('stateChanged', () => {
     remoteStreamSelector.participantStateChanged(

--- a/Calling/ClientApp/src/core/sideEffects.ts
+++ b/Calling/ClientApp/src/core/sideEffects.ts
@@ -264,14 +264,15 @@ export const initCallAgent = (name: string, callEndedHandler: (reason: CallEndRe
         // if remote participants have changed, subscribe to the added remote participants
         addedCall.on('remoteParticipantsUpdated', (ev): void => {
           // for each of the added remote participants, subscribe to events and then just update as well in case the update has already happened
-            ev.added.forEach((addedRemoteParticipant) => {
+          ev.added.forEach((addedRemoteParticipant) => {
             subscribeToParticipant(addedRemoteParticipant, addedCall, dispatch);
-            dispatch(setParticipants([...state.calls.remoteParticipants, addedRemoteParticipant]))
+            dispatch(setParticipants([...state.calls.remoteParticipants, addedRemoteParticipant]));
           });
 
-          ev.removed.forEach((removedRemoteParticipant) => {
-            dispatch(setParticipants([...state.calls.remoteParticipants.filter(remoteParticipant => { return remoteParticipant !== removedRemoteParticipant }) ]))
-          });
+          // We don't use the actual value we are just going to reset the remoteParticipants based on the call
+          if (ev.removed.length > 0) {
+            dispatch(setParticipants([...addedCall.remoteParticipants.values()]));
+          }
         });
 
         dispatch(setParticipants([...state.calls.remoteParticipants]));

--- a/Calling/ClientApp/src/core/sideEffects.ts
+++ b/Calling/ClientApp/src/core/sideEffects.ts
@@ -88,7 +88,7 @@ const subscribeToParticipant = (
   call: Call,
   dispatch: Dispatch
 ): void => {
-  let remoteStreamSelector = RemoteStreamSelector.getInstance(dispatch);
+  let remoteStreamSelector = RemoteStreamSelector.getInstance(1, dispatch);
 
   participant.on('stateChanged', () => {
     remoteStreamSelector.participantStateChanged(


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* SDK only support 1 remote stream currently. Introducing new feature that allows media gallery to only render 1 stream at a time base on a criteria, should be able to dial up the number of streams easily once SDK supports more.
For more information about the criteria please checkout this doc https://microsoft-my.sharepoint-df.com/:w:/p/abelsaba/EeT7O7HPGuVDji-hnHN77RYBqmbFuprTIbIW2tmERNEf_g?e=ryE0t6 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x] Yes
[] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
After running the sample code locally, test by creating group meeting with multiple clients, turn on/off video and mute/unmute remote participants and notice the behavior of the media gallery, which streams are being rendered
```

## What to Check
Verify that the following are valid
* Edge cases
* Feedback regarding the criteria

## Other Information
<!-- Add any other helpful information that may be needed here. -->