### PR TITLE
Do not enable CORS in backend

### DIFF
--- a/Calling/Startup.cs
+++ b/Calling/Startup.cs
@@ -12,8 +12,6 @@ namespace Calling
 {
     public class Startup
     {
-        private const string AllowAnyOrigin = nameof(AllowAnyOrigin);
-
         public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
@@ -23,20 +21,6 @@ namespace Calling
 
         public void ConfigureServices(IServiceCollection services)
         {
-            // Allow CORS as our client may be hosted on a different domain.
-            services.AddCors(options =>
-            {
-                options.AddPolicy(AllowAnyOrigin,
-                    builder =>
-                    {
-                        builder.SetIsOriginAllowed(origin => true);
-                        builder.AllowCredentials();
-                        builder.AllowAnyMethod();
-                        builder.AllowAnyHeader();
-                    }
-                );
-            });
-
             services.AddControllers();
 
             // In production, the React files will be served from this directory
@@ -53,8 +37,6 @@ namespace Calling
             app.UseSpaStaticFiles();
 
             app.UseRouting();
-
-            app.UseCors(AllowAnyOrigin);
 
             app.UseEndpoints(endpoints =>
             {


### PR DESCRIPTION
## Purpose

Prior to this PR, the backend allowed CORS requests from arbitrary domains and allowed credentials to be returned by the browser. This sample serves an SPA from the same backend as the other endpoints, so CORS is unnecessary.
Disable CORS to set the right precedent.


## Does this introduce a breaking change?

```
[ ] Yes
[ x ] No
```

If any users built off of this sample and do serve the react app and the other endpoints from different domains, they do need to allow CORS, but should do so only for whitelisted domain(s) that serve the frontend and still not expose credentials.

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Sanity test UX behaviour by running locally and testing basic scenarios: make / join a call; screen share; enable/disable mic and camera.
* Repeat with sample deployed to Azure, to ensure CORS isn't required in production environments.