### PR TITLE
Fix re-render problem of join/leave

### DIFF
--- a/Calling/ClientApp/src/core/sideEffects.ts
+++ b/Calling/ClientApp/src/core/sideEffects.ts
@@ -270,7 +270,7 @@ export const initCallAgent = (name: string, callEndedHandler: (reason: CallEndRe
           // for each of the added remote participants, subscribe to events and then just update as well in case the update has already happened
           ev.added.forEach((addedRemoteParticipant) => {
             subscribeToParticipant(addedRemoteParticipant, addedCall, dispatch);
-            dispatch(setParticipants([...state.calls.remoteParticipants, addedRemoteParticipant]));
+            dispatch(setParticipants([...addedCall.remoteParticipants, addedRemoteParticipant]));
           });
 
           // We don't use the actual value we are just going to reset the remoteParticipants based on the call

--- a/Calling/ClientApp/src/core/sideEffects.ts
+++ b/Calling/ClientApp/src/core/sideEffects.ts
@@ -268,9 +268,10 @@ export const initCallAgent = (name: string, callEndedHandler: (reason: CallEndRe
         // if remote participants have changed, subscribe to the added remote participants
         addedCall.on('remoteParticipantsUpdated', (ev): void => {
           // for each of the added remote participants, subscribe to events and then just update as well in case the update has already happened
+          const state = getState();
           ev.added.forEach((addedRemoteParticipant) => {
             subscribeToParticipant(addedRemoteParticipant, addedCall, dispatch);
-            dispatch(setParticipants([...addedCall.remoteParticipants, addedRemoteParticipant]));
+            dispatch(setParticipants([...state.calls.remoteParticipants, addedRemoteParticipant]));
           });
 
           // We don't use the actual value we are just going to reset the remoteParticipants based on the call


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Fix re-render problem when participants join/leave
Cause:
The state variable is not up-to-date(awalys initial state) when event handler is running, which caused an interesting state change chain:
[allParticipants] -> [no participants] -> [back to all participants]

Fix:
Get the latest state every time for the handler instead

TODO: The best design to avoid this problem is not to get state as much as possible in this sideEffect, addParticipants and removeParticipants should be added in reducer to avoid getState directly in sideEffect file

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->