### PR TITLE
updating media gallery to gracefully handle 1 remote participant

### DIFF
--- a/Calling/ClientApp/src/components/MediaGallery.tsx
+++ b/Calling/ClientApp/src/components/MediaGallery.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
-import { mediaGalleryGridStyle, mediaGalleryStyle } from './styles/MediaGallery.styles';
+import { mediaGalleryGridStyle, mediaGalleryStyle, mediaGallerySubstageStyle, substageMediaGalleryStyle } from './styles/MediaGallery.styles';
 import { RemoteParticipant, LocalVideoStream } from '@azure/communication-calling';
 import { utils } from '../Utils/Utils';
 import LocalStreamMedia from './LocalStreamMedia';
 import RemoteStreamMedia from './RemoteStreamMedia';
 import { SelectionState } from 'core/RemoteStreamSelector';
+import { Stack } from '@fluentui/react';
+import { Constants } from '../core/constants'
 
 export interface MediaGalleryProps {
   userId: string;
@@ -18,17 +20,38 @@ export default (props: MediaGalleryProps): JSX.Element => {
   const [gridCol, setGridCol] = useState(1);
   const [gridRow, setGridRow] = useState(1);
 
+  if (Constants.DOMINANT_PARTICIPANTS_COUNT < 1 || Constants.DOMINANT_PARTICIPANTS_COUNT > 8) {
+    console.error("Please use a value for dominante participants between 1 <= x <= 8")
+  }
+
+  // we only are going to support up to a 3x3 grid for today (1 local + 8 remote)
+  const rows = [1,1,2,2,2,2,3,3,3]
+  const cols = [1,2,2,2,3,3,3,3,3]
+
   const calculateNumberOfRows = React.useCallback(
-    (participants, gridCol) => Math.ceil((participants.length + 1) / gridCol),
+    (participants, maxStreamsToRender) => {
+      const length = Math.min(participants.length, maxStreamsToRender);
+      if (length - 1 >= rows.length) {
+        return 3;
+      }
+
+      return rows[length];
+    },
     []
   );
+
   const calculateNumberOfColumns = React.useCallback(
-    (participants) => (participants && participants.length > 0 ? Math.ceil(Math.sqrt(participants.length + 1)) : 1),
-    []
-  );
+    (participants, maxStreamsToRender) => {
+      const length = Math.min(participants.length, maxStreamsToRender);
+      if (length - 1 >= cols.length) {
+        return 3;
+      }
+
+      return cols[length];
+    }, []);
+
   const getMediaGalleryTilesForParticipants = (
     participants: RemoteParticipant[],
-    userId: string,
     displayName: string
   ): JSX.Element[] => {
     const remoteParticipantsMediaGalleryItems = participants.map((participant) => (
@@ -57,21 +80,61 @@ export default (props: MediaGalleryProps): JSX.Element => {
     return remoteParticipantsMediaGalleryItems;
   };
 
-  const numberOfColumns = calculateNumberOfColumns(props.remoteParticipants);
-  if (numberOfColumns !== gridCol) setGridCol(numberOfColumns);
-  const numberOfRows = calculateNumberOfRows(props.remoteParticipants, gridCol);
+  const getSubstageMediaGalleryTilesForParticipants = (
+    participants: RemoteParticipant[]
+  ): JSX.Element[] => {
+    const remoteParticipantsMediaGalleryItems = participants.map((participant) => (
+      <div key={`${utils.getId(participant.identifier)}-tile`} className={substageMediaGalleryStyle}>
+        <RemoteStreamMedia
+          key={utils.getId(participant.identifier)}
+          stream={participant.videoStreams[0]}
+          isParticipantStreamSelected={false}
+          label={participant.displayName ?? utils.getId(participant.identifier)}
+        />
+      </div>
+    ));
+
+    return remoteParticipantsMediaGalleryItems;
+  };
+
+  const numberOfColumns = calculateNumberOfColumns(props.remoteParticipants, Constants.DOMINANT_PARTICIPANTS_COUNT);
+  if (numberOfColumns !== gridCol) setGridCol(2);
+  const numberOfRows = calculateNumberOfRows(props.remoteParticipants, Constants.DOMINANT_PARTICIPANTS_COUNT);
   if (numberOfRows !== gridRow) setGridRow(numberOfRows);
 
+  const participantsToLayout = props.remoteParticipants.sort((a, b) =>  {
+    const isParticipantADominant = props.dominantParticipants.filter((p) => p.participantId === utils.getId(a.identifier)).length > 0
+    const isParticiantBDominant = props.dominantParticipants.filter((p) => p.participantId === utils.getId(b.identifier)).length > 0
+    if (isParticipantADominant && !isParticiantBDominant) {
+      return -1;
+    }
+    else if (!isParticipantADominant && isParticiantBDominant) {
+      return 1;
+    }
+    return 0;
+  })
+
+  // we want to reserve the main stage for video streams we are going to render.
+  // we determine the number of participants to render based on how we can select dominant participants
+  const mainStageParticipants = participantsToLayout.slice(0, Constants.DOMINANT_PARTICIPANTS_COUNT);
+  // the rest of the participants will go to the sub-stage.
+  const substageParticipants = participantsToLayout.slice(Constants.DOMINANT_PARTICIPANTS_COUNT);
+  const isSubstageVisible = substageParticipants.length > 0;
   return (
-    <div
-      id="video-gallery"
-      className={mediaGalleryGridStyle}
-      style={{
-        gridTemplateRows: `repeat(${gridRow}, minmax(0, 1fr))`,
-        gridTemplateColumns: `repeat(${gridCol}, 1fr)`
-      }}
-    >
-      {getMediaGalleryTilesForParticipants(props.remoteParticipants, props.userId, props.displayName)}
-    </div>
+    <Stack style={{height: '100%'}}>
+      <div
+        id="video-gallery"
+        className={mediaGalleryGridStyle}
+        style={{
+          gridTemplateRows: `repeat(${gridRow}, minmax(0, 1fr))`,
+          gridTemplateColumns: `repeat(${gridCol}, 1fr)`
+        }}
+      >
+        {getMediaGalleryTilesForParticipants(mainStageParticipants, props.displayName)}
+      </div>
+      {isSubstageVisible && <Stack horizontal className={mediaGallerySubstageStyle}>
+        {getSubstageMediaGalleryTilesForParticipants(substageParticipants)}
+      </Stack>}
+    </Stack>
   );
 };

--- a/Calling/ClientApp/src/components/MediaGallery.tsx
+++ b/Calling/ClientApp/src/components/MediaGallery.tsx
@@ -1,12 +1,17 @@
 import React, { useState } from 'react';
-import { mediaGalleryGridStyle, mediaGalleryStyle, mediaGallerySubstageStyle, substageMediaGalleryStyle } from './styles/MediaGallery.styles';
+import {
+  mediaGalleryGridStyle,
+  mediaGalleryStyle,
+  mediaGallerySubstageStyle,
+  substageMediaGalleryStyle
+} from './styles/MediaGallery.styles';
 import { RemoteParticipant, LocalVideoStream } from '@azure/communication-calling';
 import { utils } from '../Utils/Utils';
 import LocalStreamMedia from './LocalStreamMedia';
 import RemoteStreamMedia from './RemoteStreamMedia';
 import { SelectionState } from 'core/RemoteStreamSelector';
 import { Stack } from '@fluentui/react';
-import { Constants } from '../core/constants'
+import { Constants } from '../core/constants';
 
 export interface MediaGalleryProps {
   userId: string;
@@ -21,34 +26,30 @@ export default (props: MediaGalleryProps): JSX.Element => {
   const [gridRow, setGridRow] = useState(1);
 
   if (Constants.DOMINANT_PARTICIPANTS_COUNT < 1 || Constants.DOMINANT_PARTICIPANTS_COUNT > 8) {
-    console.error("Please use a value for dominante participants between 1 <= x <= 8")
+    console.error('Please use a value for dominante participants between 1 <= x <= 8');
   }
 
   // we only are going to support up to a 3x3 grid for today (1 local + 8 remote)
-  const rows = [1,1,2,2,2,2,3,3,3]
-  const cols = [1,2,2,2,3,3,3,3,3]
+  const rows = [1, 1, 2, 2, 2, 2, 3, 3, 3];
+  const cols = [1, 2, 2, 2, 3, 3, 3, 3, 3];
 
-  const calculateNumberOfRows = React.useCallback(
-    (participants, maxStreamsToRender) => {
-      const length = Math.min(participants.length, maxStreamsToRender);
-      if (length - 1 >= rows.length) {
-        return 3;
-      }
+  const calculateNumberOfRows = React.useCallback((participants, maxStreamsToRender) => {
+    const length = Math.min(participants.length, maxStreamsToRender);
+    if (length - 1 >= rows.length) {
+      return 3;
+    }
 
-      return rows[length];
-    },
-    []
-  );
+    return rows[length];
+  }, []);
 
-  const calculateNumberOfColumns = React.useCallback(
-    (participants, maxStreamsToRender) => {
-      const length = Math.min(participants.length, maxStreamsToRender);
-      if (length - 1 >= cols.length) {
-        return 3;
-      }
+  const calculateNumberOfColumns = React.useCallback((participants, maxStreamsToRender) => {
+    const length = Math.min(participants.length, maxStreamsToRender);
+    if (length - 1 >= cols.length) {
+      return 3;
+    }
 
-      return cols[length];
-    }, []);
+    return cols[length];
+  }, []);
 
   const getMediaGalleryTilesForParticipants = (
     participants: RemoteParticipant[],
@@ -80,9 +81,7 @@ export default (props: MediaGalleryProps): JSX.Element => {
     return remoteParticipantsMediaGalleryItems;
   };
 
-  const getSubstageMediaGalleryTilesForParticipants = (
-    participants: RemoteParticipant[]
-  ): JSX.Element[] => {
+  const getSubstageMediaGalleryTilesForParticipants = (participants: RemoteParticipant[]): JSX.Element[] => {
     const remoteParticipantsMediaGalleryItems = participants.map((participant) => (
       <div key={`${utils.getId(participant.identifier)}-tile`} className={substageMediaGalleryStyle}>
         <RemoteStreamMedia
@@ -102,17 +101,18 @@ export default (props: MediaGalleryProps): JSX.Element => {
   const numberOfRows = calculateNumberOfRows(props.remoteParticipants, Constants.DOMINANT_PARTICIPANTS_COUNT);
   if (numberOfRows !== gridRow) setGridRow(numberOfRows);
 
-  const participantsToLayout = props.remoteParticipants.sort((a, b) =>  {
-    const isParticipantADominant = props.dominantParticipants.filter((p) => p.participantId === utils.getId(a.identifier)).length > 0
-    const isParticiantBDominant = props.dominantParticipants.filter((p) => p.participantId === utils.getId(b.identifier)).length > 0
+  const participantsToLayout = props.remoteParticipants.sort((a, b) => {
+    const isParticipantADominant =
+      props.dominantParticipants.filter((p) => p.participantId === utils.getId(a.identifier)).length > 0;
+    const isParticiantBDominant =
+      props.dominantParticipants.filter((p) => p.participantId === utils.getId(b.identifier)).length > 0;
     if (isParticipantADominant && !isParticiantBDominant) {
       return -1;
-    }
-    else if (!isParticipantADominant && isParticiantBDominant) {
+    } else if (!isParticipantADominant && isParticiantBDominant) {
       return 1;
     }
     return 0;
-  })
+  });
 
   // we want to reserve the main stage for video streams we are going to render.
   // we determine the number of participants to render based on how we can select dominant participants
@@ -121,7 +121,7 @@ export default (props: MediaGalleryProps): JSX.Element => {
   const substageParticipants = participantsToLayout.slice(Constants.DOMINANT_PARTICIPANTS_COUNT);
   const isSubstageVisible = substageParticipants.length > 0;
   return (
-    <Stack style={{height: '100%'}}>
+    <Stack style={{ height: '100%' }}>
       <div
         id="video-gallery"
         className={mediaGalleryGridStyle}
@@ -132,9 +132,11 @@ export default (props: MediaGalleryProps): JSX.Element => {
       >
         {getMediaGalleryTilesForParticipants(mainStageParticipants, props.displayName)}
       </div>
-      {isSubstageVisible && <Stack horizontal className={mediaGallerySubstageStyle}>
-        {getSubstageMediaGalleryTilesForParticipants(substageParticipants)}
-      </Stack>}
+      {isSubstageVisible && (
+        <Stack horizontal className={mediaGallerySubstageStyle}>
+          {getSubstageMediaGalleryTilesForParticipants(substageParticipants)}
+        </Stack>
+      )}
     </Stack>
   );
 };

--- a/Calling/ClientApp/src/components/styles/GroupCall.styles.ts
+++ b/Calling/ClientApp/src/components/styles/GroupCall.styles.ts
@@ -35,7 +35,8 @@ export const activeContainerClassName: IStackItemStyles = {
   root: {
     border: `solid 1px ${palette.neutralLighterAlt}`,
     height: 'calc(100% - 3px)',
-    display: 'initial'
+    display: 'initial',
+    width: '100%'
   }
 };
 

--- a/Calling/ClientApp/src/components/styles/MediaGallery.styles.ts
+++ b/Calling/ClientApp/src/components/styles/MediaGallery.styles.ts
@@ -13,9 +13,9 @@ export const mediaGalleryStyle = mergeStyles({
 
 export const substageMediaGalleryStyle = mergeStyles({
   padding: '0.4375rem',
-  width:'100px',
-  minWidth:'100px',
-  height:'100px',
+  width: '100px',
+  minWidth: '100px',
+  height: '100px',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
@@ -33,4 +33,4 @@ export const mediaGalleryGridStyle = mergeStyles({
 export const mediaGallerySubstageStyle = mergeStyles({
   height: '8.438rem',
   overflowX: 'auto'
-})
+});

--- a/Calling/ClientApp/src/components/styles/MediaGallery.styles.ts
+++ b/Calling/ClientApp/src/components/styles/MediaGallery.styles.ts
@@ -10,8 +10,27 @@ export const mediaGalleryStyle = mergeStyles({
   borderRight: '1px solid rgba(0,0,0,0.05)',
   borderBottom: '1px solid rgba(0,0,0,0.05)'
 });
+
+export const substageMediaGalleryStyle = mergeStyles({
+  padding: '0.4375rem',
+  width:'100px',
+  minWidth:'100px',
+  height:'100px',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  border: 0,
+  borderRight: '1px solid rgba(0,0,0,0.05)',
+  borderBottom: '1px solid rgba(0,0,0,0.05)'
+});
+
 export const mediaGalleryGridStyle = mergeStyles({
   height: '100%',
   background: palette.neutralLighterAlt,
   display: 'grid'
 });
+
+export const mediaGallerySubstageStyle = mergeStyles({
+  height: '8.438rem',
+  overflowX: 'auto'
+})

--- a/Calling/ClientApp/src/core/constants.ts
+++ b/Calling/ClientApp/src/core/constants.ts
@@ -8,5 +8,5 @@ export class Constants {
   static CONFIGURATION_LOCAL_VIDEO_PREVIEW_ID = 'ConfigurationLocalVideoPreview';
   static LOCAL_VIDEO_PREVIEW_ID = 'LocalVideoPreview';
   static MINI_HEADER_WINDOW_WIDTH = 360;
-  static DOMINTANT_PARTICIPANTS_COUNT = 1;
+  static DOMINANT_PARTICIPANTS_COUNT = 1; // The media gallery is design to work between 1 and 8 dominant participants inclusive
 }

--- a/Calling/ClientApp/src/core/sideEffects.ts
+++ b/Calling/ClientApp/src/core/sideEffects.ts
@@ -82,7 +82,7 @@ export const setShareUnshareScreen = (shareScreen: boolean) => {
 };
 
 const subscribeToParticipant = (participant: RemoteParticipant, call: Call, dispatch: Dispatch): void => {
-  const remoteStreamSelector = RemoteStreamSelector.getInstance(Constants.DOMINTANT_PARTICIPANTS_COUNT, dispatch);
+  const remoteStreamSelector = RemoteStreamSelector.getInstance(Constants.DOMINANT_PARTICIPANTS_COUNT, dispatch);
 
   participant.on('stateChanged', () => {
     remoteStreamSelector.participantStateChanged(


### PR DESCRIPTION
## Purpose
The gallery focuses on being n x n but it doesn't take into account how we're not rendering all of our participants streams. We have a new design that allows us to focus on which streams we are rendering and moving our other streams to a sub-stage.

## Does this introduce a breaking change?
```
[ ] Yes
[ x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Ran it locally

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->