### PR TITLE
undefined rendererViews that are already disposed

### DIFF
--- a/Calling/ClientApp/src/components/LocalPreview.tsx
+++ b/Calling/ClientApp/src/components/LocalPreview.tsx
@@ -31,7 +31,7 @@ export interface LocalPreviewProps {
   localVideoStream: LocalVideoStream;
 }
 
-let rendererView: VideoStreamRendererView;
+let rendererView: VideoStreamRendererView | undefined;
 
 export default (props: LocalPreviewProps): JSX.Element => {
   const imageProps = {
@@ -65,6 +65,7 @@ export default (props: LocalPreviewProps): JSX.Element => {
     return () => {
       if (rendererView) {
         rendererView.dispose();
+        rendererView = undefined;
       }
     };
   }, [props.localVideoStream]);

--- a/Calling/ClientApp/src/components/LocalStreamMedia.tsx
+++ b/Calling/ClientApp/src/components/LocalStreamMedia.tsx
@@ -54,6 +54,7 @@ export default (props: LocalStreamMediaProps): JSX.Element => {
     return () => {
       if (rendererView.current) {
         rendererView.current.dispose();
+        rendererView.current = undefined;
         setActiveStreamBeingRendered(false);
       }
     };

--- a/Calling/ClientApp/src/components/RemoteStreamMedia.tsx
+++ b/Calling/ClientApp/src/components/RemoteStreamMedia.tsx
@@ -66,6 +66,7 @@ export default (props: RemoteStreamMediaProps): JSX.Element => {
 
       if (rendererView.current) {
         rendererView.current.dispose();
+        rendererView.current = undefined;
       }
     }
   }, [stream, isParticipantStreamSelected, setShowRenderLoading, setActiveStreamBeingRendered, activeStreamBeingRendered, rendererView, streamId]);


### PR DESCRIPTION
## Purpose
With the update to calling 1.1.0-beta.2 we also need to be able to undefine renderedViews that have been disposed

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Tested locally with 2 participants turning off and on the streams

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->