### PR TITLE
Fixing participant list height and the feedback URL

### DIFF
--- a/Calling/ClientApp/src/components/EndCall.tsx
+++ b/Calling/ClientApp/src/components/EndCall.tsx
@@ -22,6 +22,7 @@ export interface EndCallProps {
 export default (props: EndCallProps): JSX.Element => {
   const goHomePage = 'Go to homepage';
   const rejoinCall = 'Rejoin call';
+  const feedbackUrl = 'https://docs.microsoft.com/en-us/answers/search.html?c=&includeChildren=&f=&type=question+OR+idea+OR+kbentry+OR+answer+OR+topic+OR+user&redirect=search%2Fsearch&sort=relevance&q=azure-communication-services';
 
   return (
     <Stack verticalAlign="center" tokens={mainStackTokens} className={endCallContainerStyle}>
@@ -37,7 +38,7 @@ export default (props: EndCallProps): JSX.Element => {
           </DefaultButton>
         </Stack>
         <div className={bottomStackFooterStyle}>
-          <a href="https://github.com/Azure/Communication/issues">Give Feedback</a>&nbsp;on this sample app on Github
+          <a href={feedbackUrl}>Give Feedback</a>&nbsp;on this sample app on Github
         </div>
       </Stack>
     </Stack>

--- a/Calling/ClientApp/src/components/styles/ParticipantStack.styles.ts
+++ b/Calling/ClientApp/src/components/styles/ParticipantStack.styles.ts
@@ -22,7 +22,7 @@ export const overFlowButtonStyles: IButtonStyles = {
   }
 };
 export const participantStackStyle = mergeStyles({
-  maxHeight: '21.875rem',
+  maxHeight: '100%',
   overflow: 'auto',
   paddingLeft: '1.125rem',
   paddingRight: '1.125rem'


### PR DESCRIPTION
## Purpose
1)  If there are too many participants, they seem to be getting cut off in the participant list. The fix is to set the height to 100%
2) The feedback URL is going to github issues and we actually want it to go to Microsoft Q&A

## Does this introduce a breaking change?
[ ] Yes
[x ] No

## Pull Request Type
What kind of change does this Pull Request introduce?


[x ] Bugfix
[ x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
Tested it locally
1) Having a call with many users
2) Clicking on the feedback link at the end of the call
