### PR TITLE
Add ARM template for deploying with an existing resource

### DIFF
--- a/deploy/azuredeployexistingresource.json
+++ b/deploy/azuredeployexistingresource.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "appName": {
+      "type": "string"
+    },
+    "sku": {
+      "type": "string",
+      "defaultValue": "F1",
+      "metadata": {
+        "description": "The SKU of App Service Plan."
+      }
+    },
+    "packageUrl": {
+      "type": "string",
+      "defaultValue": "http://github.com/azure-samples/communication-services-web-calling-hero/releases/latest/download/group-calling.zip"
+    }
+  },
+  "variables": {
+    "location": "[resourceGroup().location]",
+    "appServicePlanPortalName": "[concat('AppServicePlan-', parameters('appName'))]",
+    "communicationServicesResourceId": "<Enter your Azure Communication Services Resource Id>"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Web/serverfarms",
+      "apiVersion": "2020-06-01",
+      "name": "[variables('appServicePlanPortalName')]",
+      "location": "[resourceGroup().location]",
+      "sku": {
+        "name": "[parameters('sku')]"
+      },
+      "kind": "linux"
+    },
+    {
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2020-06-01",
+      "name": "[parameters('appName')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanPortalName'))]"
+      ],
+      "properties": {
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanPortalName'))]"
+      },
+      "resources": [
+        {
+          "name": "appsettings",
+          "type": "config",
+          "apiVersion": "2021-03-01",
+          "dependsOn": [
+            "[resourceId('Microsoft.Web/sites', parameters('appName'))]"
+          ],
+          "tags": {
+            "displayName": "appsettings"
+          },
+          "properties": {
+            "ResourceConnectionString": "[listkeys(variables('communicationServicesResourceId'), '2020-08-20' ).primaryConnectionString]",
+            "WEBSITE_NODE_DEFAULT_VERSION": "~12"
+          }
+        },
+        {
+            "name": "MSDeploy",
+            "type": "extensions",
+            "location": "[resourceGroup().location]",
+            "apiVersion": "2021-03-01",
+            "dependsOn": [
+              "[resourceId('Microsoft.Web/sites', parameters('appName'))]",
+              "[resourceId('Microsoft.Web/sites/config', parameters('appName'), 'appsettings')]"
+            ],
+            "properties": {
+              "packageUri": "[parameters('packageUrl')]"
+            }
+          }
+      ]
+    }
+  ]
+}

--- a/deploy/azuredeployexistingresource.json
+++ b/deploy/azuredeployexistingresource.json
@@ -11,16 +11,13 @@
       "metadata": {
         "description": "The SKU of App Service Plan."
       }
-    },
-    "packageUrl": {
-      "type": "string",
-      "defaultValue": "http://github.com/azure-samples/communication-services-web-calling-hero/releases/latest/download/group-calling.zip"
     }
   },
   "variables": {
+    "communicationServicesResourceId": "<Enter your Azure Communication Services Resource Id>",
     "location": "[resourceGroup().location]",
     "appServicePlanPortalName": "[concat('AppServicePlan-', parameters('appName'))]",
-    "communicationServicesResourceId": "<Enter your Azure Communication Services Resource Id>"
+    "packageUrl": "http://github.com/azure-samples/communication-services-web-calling-hero/releases/latest/download/group-calling.zip"
   },
   "resources": [
     {
@@ -70,7 +67,7 @@
               "[resourceId('Microsoft.Web/sites/config', parameters('appName'), 'appsettings')]"
             ],
             "properties": {
-              "packageUri": "[parameters('packageUrl')]"
+              "packageUri": "[variables('packageUrl')]"
             }
           }
       ]


### PR DESCRIPTION
## Purpose

* To add a new ARM template where an existing Azure Communication Services resource is used instead of deploying a new one
* One use of this template will be from the 'Sample applications' blade in the Azure Portal, where users can deploy the calling hero sample using the existing resource. Mock up:


![2022-05-24 13_46_55-sample-apps-call](https://user-images.githubusercontent.com/43504546/170131674-41035094-e8c7-4b13-bc2e-395764499a9b.png)

## Pull Request Type

<!-- What kind of change does this Pull Request introduce? -->
<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: new ARM template
```

## Upstream sample reference

<!-- In most cases, a change here synchronizes this sample with the upstream sample. -->

Links to PR(s) that made the original change in the [upstream sample](https://github.com/Azure/communication-ui-library/tree/main/samples/Calling):

* ...

## How to Test

*  Get the code

```
git clone [repo-address]
cd [repo-name]
```

* Set Azure Communication Services Resource Id
1. Retrieve the resource id for your Communication Services resource
1. Open deploy/azuredeployexistingresource.json
1. Set `communicationServicesResourceId`

* Test the code

<!-- Add steps to run the tests suite and/or manually test. -->
1. Deploy the ARM template via CLI or custom deployment in Azure Portal (portal.azure.com/#create/Microsoft.Template)

## What to Check

Verify that the following are valid
* Confirm can join call successfully



![2022-05-24 14_05_40-azuredeployexistingresource json - communication-services-web-chat-hero - Visual](https://user-images.githubusercontent.com/43504546/170132441-43358e85-acf5-4727-ba28-c30b31e25c8e.png)




## Other Information

<!-- Add any other helpful information that may be needed here. -->
