### PR TITLE
Update Deploy to Azure templates to ensure azure portal displays correct validation errors

### DIFF
--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -41,7 +41,8 @@
       "sku": {
         "name": "[parameters('sku')]"
       },
-      "kind": "linux"
+      "kind": "linux",
+      "properties": {}
     },
     {
       "type": "Microsoft.Web/sites",

--- a/deploy/azuredeployexistingresource.json
+++ b/deploy/azuredeployexistingresource.json
@@ -28,7 +28,8 @@
       "sku": {
         "name": "[parameters('sku')]"
       },
-      "kind": "linux"
+      "kind": "linux",
+      "properties": {}
     },
     {
       "type": "Microsoft.Web/sites",


### PR DESCRIPTION
## What

Update Deploy to Azure templates to ensure azure portal displays correct validation errors

## Why

Azure portal will error with a non-descript validation error if your free tier is full. Adding this circumvents a bug and ensures the validation error correctly says that you have no availability left in your F1 tier.