### PR TITLE
updating deploy script

### DIFF
--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -41,7 +41,6 @@
       "sku": {
         "name": "[parameters('sku')]"
       },
-      "kind": "linux",
       "properties": {}
     },
     {
@@ -69,7 +68,7 @@
           },
           "properties": {
             "ResourceConnectionString": "[listkeys(variables('commsName'), '2020-08-20-preview' ).primaryConnectionString]",
-            "WEBSITE_NODE_DEFAULT_VERSION": "~12"
+            "WEBSITE_NODE_DEFAULT_VERSION": "~14"
           }
         },
         {


### PR DESCRIPTION
I noticed there was a slight diff between the Call and Chat hero sample ARM templates. I am updating the configurations so they are near identical

remove "kind": "linux" from the serverfarm resource
change WEBSITE_NODE_DEFAULT_VERSION to "~14"  from "~12"