### PR TITLE
Fix teams interop call initiation

### DIFF
--- a/Calling/src/app/App.tsx
+++ b/Calling/src/app/App.tsx
@@ -90,7 +90,8 @@ const App = (): JSX.Element => {
           startCallHandler={async (callDetails) => {
             setDisplayName(callDetails.displayName);
 
-            let callLocator: CallAdapterLocator | undefined = callDetails.callLocator || getTeamsLinkFromUrl() || getGroupIdFromUrl();
+            let callLocator: CallAdapterLocator | undefined =
+              callDetails.callLocator || getTeamsLinkFromUrl() || getGroupIdFromUrl();
 
             callLocator = callLocator || createGroupId();
 

--- a/Calling/src/app/App.tsx
+++ b/Calling/src/app/App.tsx
@@ -90,7 +90,7 @@ const App = (): JSX.Element => {
           startCallHandler={async (callDetails) => {
             setDisplayName(callDetails.displayName);
 
-            let callLocator: CallAdapterLocator | undefined = getTeamsLinkFromUrl() || getGroupIdFromUrl();
+            let callLocator: CallAdapterLocator | undefined = callDetails.callLocator || getTeamsLinkFromUrl() || getGroupIdFromUrl();
 
             callLocator = callLocator || createGroupId();
 

--- a/Calling/src/app/views/HomeScreen.tsx
+++ b/Calling/src/app/views/HomeScreen.tsx
@@ -26,7 +26,7 @@ import { DisplayNameField } from './DisplayNameField';
 import { TeamsMeetingLinkLocator } from '@azure/communication-calling';
 
 export interface HomeScreenProps {
-  startCallHandler(callDetails: { displayName: string }): void;
+  startCallHandler(callDetails: { displayName: string; callLocator?: TeamsMeetingLinkLocator }): void;
   joiningExistingCall: boolean;
 }
 
@@ -99,7 +99,8 @@ export const HomeScreen = (props: HomeScreenProps): JSX.Element => {
                 saveDisplayNameToLocalStorage(displayName);
 
                 props.startCallHandler({
-                  displayName
+                  displayName,
+                  callLocator,
                 });
               }
             }}

--- a/Calling/src/app/views/HomeScreen.tsx
+++ b/Calling/src/app/views/HomeScreen.tsx
@@ -100,7 +100,7 @@ export const HomeScreen = (props: HomeScreenProps): JSX.Element => {
 
                 props.startCallHandler({
                   displayName,
-                  callLocator,
+                  callLocator
                 });
               }
             }}


### PR DESCRIPTION
Broken by https://github.com/Azure-Samples/communication-services-web-calling-hero/pull/161

Conditional compilation of the upstream sample was wrong.

## Verification

* Start a group call
* Join a group call via deep link
* Join a Teams meeting from home page
* Join a Teams meeting from deep link