### PR TITLE
updating server code to allow for an admin user id

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,183 +1,94 @@
-
 ---
-
 page_type: sample
-
 languages:
-
 - typescript
-
 - nodejs
-
 products:
-
 - azure
-
 - azure-communication-services
-
 ---
-
-  
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure-Samples%2Fcommunication-services-web-calling-hero%2Fmain%2Fdeploy%2Fazuredeploy.json)
 
-  
-
 # Group Calling Sample
-
-  
 
 ## Overview
 
-  
-
 This is a sample application to show how we can use the `@azure/communication-react` package to build a calling experience.
-
-Learn more about the [Azure Communication Services UI Library](https://azure.github.io/communication-ui-library/).
-
+Learn more about the [Azure Communication Services UI Library](https://azure.github.io/communication-ui-library/). 
 The client-side application is a React based user interface. Alongside this front-end is a NodeJS web application powered by ExpressJS that performs functionality like minting new user tokens for each call participant.
-
-  
 
 Additional documentation for this sample can be found on [Microsoft Docs](https://docs.microsoft.com/azure/communication-services/samples/calling-hero-sample).
 
-  
-
 Before contributing to this sample, please read our [contribution guidelines](./CONTRIBUTING.md).
-
-  
 
 ![Homepage](./Calling/Media/homepage-sample-calling.png)
 
-  
-
 ## ❤️ Feedback
-
-We appreciate your feedback and energy helping us improve our services. [Please let us know if you are satisfied with ACS through this survey](https://microsoft.qualtrics.com/jfe/form/SV_5dtYL81xwHnUVue).
-
-  
+We appreciate your feedback and energy helping us improve our services. [Please let us know if you are satisfied with ACS through this survey](https://microsoft.qualtrics.com/jfe/form/SV_5dtYL81xwHnUVue). 
 
 ## Prerequisites
 
-  
-
 - [Visual Studio Code (Stable Build)](https://code.visualstudio.com/Download)
-
 - [Node.js (12.18.4 and above)](https://nodejs.org/en/download/)
-
 - Create an Azure account with an active subscription. For details, see [Create an account for free](https://azure.microsoft.com/free/?WT.mc_id=A261C142F).
-
 - Create an Azure Communication Services resource. For details, see [Create an Azure Communication Resource](https://docs.microsoft.com/azure/communication-services/quickstarts/create-communication-resource). You'll need to record your resource **connection string** for this quickstart.
 
-  
-
 ## Code structure
-
 - ./Calling/src/app: Where the client code lives
-
-- ./Calling/src/app/App.tsx: Entry point into the calling sample
-
-- ./Calling/src/app/views/HomeScreen.tsx:
-
-- ./Calling/src/app/views/CallScreen.tsx:
-
-- ./Calling/src/app/views/EndCall.tsx:
-
-- ./Calling/src/app/views/UnsupportedBrowserPage.tsx:
-
+- ./Calling/src/app/App.tsx:  Entry point into the calling sample 
+- ./Calling/src/app/views/HomeScreen.tsx:  
+- ./Calling/src/app/views/CallScreen.tsx:  
+- ./Calling/src/app/views/EndCall.tsx:  
+- ./Calling/src/app/views/UnsupportedBrowserPage.tsx:  
 - ./Server: server code
-
 - ./Server/appsettings.json: Where to put your azure communication services connection string
-
-  
 
 ## Before running the sample for the first time
 
-  
-
 1. Open an instance of PowerShell, Windows Terminal, Command Prompt or equivalent and navigate to the directory that you'd like to clone the sample to.
 
-  
-
-```shell
-
-git clone https://github.com/Azure-Samples/communication-services-web-calling-hero.git`
-
-```
-
+   ```shell
+   git clone https://github.com/Azure-Samples/communication-services-web-calling-hero.git`
+   ```
+   
 1. Get the `Connection String` from the Azure portal. For more information on connection strings, see [Create an Azure Communication Resources](https://docs.microsoft.com/azure/communication-services/quickstarts/create-communication-resource)
-
 2. Once you get the `Connection String`, add the connection string to the **samples/Server/appsetting.json** file. Input your connection string in the variable: `ResourceConnectionString`.
-* There are two other properties in the appsettings.json file (EndpointUrl, AdminUserId). For the Calling Hero Sample these two properties are unnecessary. We use this file with our chat hero sample and that is where those strings are used.
 
-  
+* There are two other properties in the appsettings.json file (EndpointUrl, AdminUserId). For the Calling Hero Sample these two properties are unnecessary. We use this file with our chat hero sample and that is where those strings are used.
 
 ## Local run
 
-  
-
 1. Install dependencies
 
-  
-
-```bash
-
-npm run setup
-
-```
-
-  
+    ```bash
+    npm run setup
+    ```
 
 1. Start the calling app
 
-  
+    ```bash
+    npm run start
+    ```
 
-```bash
-
-npm run start
-
-```
-
-  
-
-This will open a client server on port 3000 that serves the website files, and an api server on port 8080 that performs functionality like minting tokens for call participants.
-
-  
+    This will open a client server on port 3000 that serves the website files, and an api server on port 8080 that performs functionality like minting tokens for call participants.
 
 ### Troubleshooting
 
-  
-
 1. The app shows an "Unsupported browser" screen but I am on a [supported browser](https://docs.microsoft.com/en-us/azure/communication-services/concepts/voice-video-calling/calling-sdk-features#calling-client-library-browser-support).
 
-  
-
-If your app is being served over a hostname other then localhost, you must serve traffic over https and not http.
-
-  
+	If your app is being served over a hostname other then localhost, you must serve traffic over https and not http.
 
 ## Publish to Azure
 
-  
-
-1.  `npm run setup`
-
-2.  `npm run build`
-
-3.  `npm run package`
-
+1. `npm run setup`
+2. `npm run build`
+3. `npm run package`
 4. Use the [Azure extension](https://code.visualstudio.com/docs/azure/extensions) and deploy the `Calling/dist` directory to your app service
-
-  
 
 ## Additional Reading
 
-  
-
 - [Azure Communication Services - UI Library](https://azure.github.io/communication-ui-library/) - To learn more about what the `@azure/communication-react` package offers.
-
 - [Azure Communication Calling SDK](https://docs.microsoft.com/azure/communication-services/concepts/voice-video-calling/calling-sdk-features) - To learn more about the calling web sdk
-
 - [FluentUI](https://developer.microsoft.com/fluentui#/) - Microsoft powered UI library
-
 - [React](https://reactjs.org/) - Library for building user interfaces

--- a/README.md
+++ b/README.md
@@ -1,94 +1,183 @@
+
 ---
+
 page_type: sample
+
 languages:
+
 - typescript
+
 - nodejs
+
 products:
+
 - azure
+
 - azure-communication-services
+
 ---
+
+  
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure-Samples%2Fcommunication-services-web-calling-hero%2Fmain%2Fdeploy%2Fazuredeploy.json)
 
+  
+
 # Group Calling Sample
+
+  
 
 ## Overview
 
+  
+
 This is a sample application to show how we can use the `@azure/communication-react` package to build a calling experience.
-Learn more about the [Azure Communication Services UI Library](https://azure.github.io/communication-ui-library/). 
+
+Learn more about the [Azure Communication Services UI Library](https://azure.github.io/communication-ui-library/).
+
 The client-side application is a React based user interface. Alongside this front-end is a NodeJS web application powered by ExpressJS that performs functionality like minting new user tokens for each call participant.
+
+  
 
 Additional documentation for this sample can be found on [Microsoft Docs](https://docs.microsoft.com/azure/communication-services/samples/calling-hero-sample).
 
+  
+
 Before contributing to this sample, please read our [contribution guidelines](./CONTRIBUTING.md).
+
+  
 
 ![Homepage](./Calling/Media/homepage-sample-calling.png)
 
+  
+
 ## ❤️ Feedback
-We appreciate your feedback and energy helping us improve our services. [Please let us know if you are satisfied with ACS through this survey](https://microsoft.qualtrics.com/jfe/form/SV_5dtYL81xwHnUVue). 
+
+We appreciate your feedback and energy helping us improve our services. [Please let us know if you are satisfied with ACS through this survey](https://microsoft.qualtrics.com/jfe/form/SV_5dtYL81xwHnUVue).
+
+  
 
 ## Prerequisites
 
+  
+
 - [Visual Studio Code (Stable Build)](https://code.visualstudio.com/Download)
+
 - [Node.js (12.18.4 and above)](https://nodejs.org/en/download/)
+
 - Create an Azure account with an active subscription. For details, see [Create an account for free](https://azure.microsoft.com/free/?WT.mc_id=A261C142F).
+
 - Create an Azure Communication Services resource. For details, see [Create an Azure Communication Resource](https://docs.microsoft.com/azure/communication-services/quickstarts/create-communication-resource). You'll need to record your resource **connection string** for this quickstart.
 
+  
+
 ## Code structure
+
 - ./Calling/src/app: Where the client code lives
-- ./Calling/src/app/App.tsx:  Entry point into the calling sample 
-- ./Calling/src/app/views/HomeScreen.tsx:  
-- ./Calling/src/app/views/CallScreen.tsx:  
-- ./Calling/src/app/views/EndCall.tsx:  
-- ./Calling/src/app/views/UnsupportedBrowserPage.tsx:  
+
+- ./Calling/src/app/App.tsx: Entry point into the calling sample
+
+- ./Calling/src/app/views/HomeScreen.tsx:
+
+- ./Calling/src/app/views/CallScreen.tsx:
+
+- ./Calling/src/app/views/EndCall.tsx:
+
+- ./Calling/src/app/views/UnsupportedBrowserPage.tsx:
+
 - ./Server: server code
+
 - ./Server/appsettings.json: Where to put your azure communication services connection string
+
+  
 
 ## Before running the sample for the first time
 
+  
+
 1. Open an instance of PowerShell, Windows Terminal, Command Prompt or equivalent and navigate to the directory that you'd like to clone the sample to.
 
-   ```shell
-   git clone https://github.com/Azure-Samples/communication-services-web-calling-hero.git`
-   ```
-   
+  
+
+```shell
+
+git clone https://github.com/Azure-Samples/communication-services-web-calling-hero.git`
+
+```
+
 1. Get the `Connection String` from the Azure portal. For more information on connection strings, see [Create an Azure Communication Resources](https://docs.microsoft.com/azure/communication-services/quickstarts/create-communication-resource)
-1. Once you get the `Connection String`, add the connection string to the **samples/Server/appsetting.json** file. Input your connection string in the variable: `ResourceConnectionString`.
-1. Get the `Endpoint string` from the Azure portal. For more information on Endpoint strings, see [Create an Azure Communication Resources](https://docs.microsoft.com/azure/communication-services/quickstarts/create-communication-resource)
-1. Once you get the `Endpoint String`, add the endpoint string to the **samples/Server/appsetting.json** file. Input your endpoint string in the variable `EndpointUrl`
+
+2. Once you get the `Connection String`, add the connection string to the **samples/Server/appsetting.json** file. Input your connection string in the variable: `ResourceConnectionString`.
+* There are two other properties in the appsettings.json file (EndpointUrl, AdminUserId). For the Calling Hero Sample these two properties are unnecessary. We use this file with our chat hero sample and that is where those strings are used.
+
+  
+
 ## Local run
+
+  
 
 1. Install dependencies
 
-    ```bash
-    npm run setup
-    ```
+  
+
+```bash
+
+npm run setup
+
+```
+
+  
 
 1. Start the calling app
 
-    ```bash
-    npm run start
-    ```
+  
 
-    This will open a client server on port 3000 that serves the website files, and an api server on port 8080 that performs functionality like minting tokens for call participants.
+```bash
+
+npm run start
+
+```
+
+  
+
+This will open a client server on port 3000 that serves the website files, and an api server on port 8080 that performs functionality like minting tokens for call participants.
+
+  
 
 ### Troubleshooting
 
+  
+
 1. The app shows an "Unsupported browser" screen but I am on a [supported browser](https://docs.microsoft.com/en-us/azure/communication-services/concepts/voice-video-calling/calling-sdk-features#calling-client-library-browser-support).
 
-	If your app is being served over a hostname other then localhost, you must serve traffic over https and not http.
+  
+
+If your app is being served over a hostname other then localhost, you must serve traffic over https and not http.
+
+  
 
 ## Publish to Azure
 
-1. `npm run setup`
-2. `npm run build`
-3. `npm run package`
+  
+
+1.  `npm run setup`
+
+2.  `npm run build`
+
+3.  `npm run package`
+
 4. Use the [Azure extension](https://code.visualstudio.com/docs/azure/extensions) and deploy the `Calling/dist` directory to your app service
+
+  
 
 ## Additional Reading
 
-- [Azure Communication Services - UI Library](https://azure.github.io/communication-ui-library/) - To learn more about what the `@azure/communication-react` package offers.
-- [Azure Communication Calling SDK](https://docs.microsoft.com/azure/communication-services/concepts/voice-video-calling/calling-sdk-features) - To learn more about the calling web sdk
-- [FluentUI](https://developer.microsoft.com/fluentui#/) - Microsoft powered UI library
-- [React](https://reactjs.org/) - Library for building user interfaces
+  
 
+- [Azure Communication Services - UI Library](https://azure.github.io/communication-ui-library/) - To learn more about what the `@azure/communication-react` package offers.
+
+- [Azure Communication Calling SDK](https://docs.microsoft.com/azure/communication-services/concepts/voice-video-calling/calling-sdk-features) - To learn more about the calling web sdk
+
+- [FluentUI](https://developer.microsoft.com/fluentui#/) - Microsoft powered UI library
+
+- [React](https://reactjs.org/) - Library for building user interfaces

--- a/Server/appsettings.json
+++ b/Server/appsettings.json
@@ -8,5 +8,6 @@
   },
   "AllowedHosts": "*",
   "ResourceConnectionString": "REPLACE_WITH_CONNECTION_STRING",
-  "EndpointUrl":"REPLACE_WITH_ENDPOINT_URL"
+  "EndpointUrl":"REPLACE_WITH_ENDPOINT_URL",
+  "AdminUserId": "REPLACE_WITH_ADMIN_USER_ID"
 }

--- a/Server/src/app.ts
+++ b/Server/src/app.ts
@@ -11,7 +11,6 @@ import path from 'path';
 import issueToken from './routes/issueToken';
 import refreshToken from './routes/refreshToken';
 import getEndpointUrl from './routes/getEndpointUrl';
-import isValidThread from './routes/isValidThread';
 import userConfig from './routes/userConfig';
 import createThread from './routes/createThread';
 import addUser from './routes/addUser';
@@ -53,12 +52,6 @@ app.use('/getEndpointUrl', cors(), getEndpointUrl);
  * purpose: Chat,Calling: get ACS token with the given scope
  */
 app.use('/token', cors(), issueToken);
-
-/**
- * route: /isValidThread
- * purpose: Chat: check if thread is valid
- */
-app.use('/isValidThread', cors(), isValidThread);
 
 /**
  * route: /userConfig

--- a/Server/src/lib/chat/moderator.ts
+++ b/Server/src/lib/chat/moderator.ts
@@ -4,11 +4,10 @@
 import { AzureCommunicationTokenCredential } from '@azure/communication-common';
 import { ChatClient, CreateChatThreadOptions, CreateChatThreadRequest } from '@azure/communication-chat';
 import { getEndpoint } from '../envHelper';
-import { threadIdToModeratorCredentialMap } from './threadIdToModeratorTokenMap';
-import { createUser, getToken } from '../identityClient';
+import { getAdminUser, getToken } from '../identityClient';
 
 export const createThread = async (topicName?: string): Promise<string> => {
-  const user = await createUser();
+  const user = await getAdminUser();
 
   const credential = new AzureCommunicationTokenCredential({
     tokenRefresher: async () => (await getToken(user, ['chat', 'voip'])).token,
@@ -35,6 +34,5 @@ export const createThread = async (topicName?: string): Promise<string> => {
     throw new Error(`Invalid or missing ID for newly created thread ${result.chatThread}`);
   }
 
-  threadIdToModeratorCredentialMap.set(threadID, credential);
   return threadID;
 };

--- a/Server/src/lib/envHelper.ts
+++ b/Server/src/lib/envHelper.ts
@@ -17,3 +17,13 @@ export const getEndpoint = (): string => {
   const uri = new URL(process.env['EndpointUrl'] || appSettings.EndpointUrl);
   return `${uri.protocol}//${uri.host}`;
 };
+
+export const getAdminUserId = (): string => {
+  const adminUserId = process.env['AdminUserId'] || appSettings.AdminUserId;
+
+  if (!adminUserId) {
+    throw new Error('No ACS Admin UserId provided');
+  }
+
+  return adminUserId;
+};

--- a/Server/src/lib/identityClient.ts
+++ b/Server/src/lib/identityClient.ts
@@ -8,8 +8,7 @@ import {
   TokenScope
 } from '@azure/communication-identity';
 import { CommunicationUserIdentifier } from '@azure/communication-common';
-import { OperationOptions } from '@azure/core-http';
-import { getResourceConnectionString } from './envHelper';
+import { getResourceConnectionString, getAdminUserId } from './envHelper';
 
 // lazy init to allow mocks in test
 let identityClient: CommunicationIdentityClient | undefined = undefined;
@@ -17,11 +16,10 @@ const getIdentityClient = (): CommunicationIdentityClient =>
   identityClient ?? (identityClient = new CommunicationIdentityClient(getResourceConnectionString()));
 
 // replicate here to allow for mocks in tests
-export const createUser = (): Promise<CommunicationUserIdentifier> => getIdentityClient().createUser();
-export const getToken = (
-  user: CommunicationUserIdentifier,
-  scopes: TokenScope[],
-  options?: OperationOptions
-): Promise<CommunicationAccessToken> => getIdentityClient().getToken(user, scopes);
+export const getAdminUser = (): CommunicationUserIdentifier => {
+  return { communicationUserId: getAdminUserId() };
+};
+export const getToken = (user: CommunicationUserIdentifier, scopes: TokenScope[]): Promise<CommunicationAccessToken> =>
+  getIdentityClient().getToken(user, scopes);
 export const createUserAndToken = (scopes: TokenScope[]): Promise<CommunicationUserToken> =>
   getIdentityClient().createUserAndToken(scopes);

--- a/Server/src/routes/addUser.ts
+++ b/Server/src/routes/addUser.ts
@@ -2,9 +2,10 @@
 // Licensed under the MIT license.
 
 import { ChatClient } from '@azure/communication-chat';
+import { AzureCommunicationTokenCredential } from '@azure/communication-common';
 import * as express from 'express';
 import { getEndpoint } from '../lib/envHelper';
-import { threadIdToModeratorCredentialMap } from '../lib/chat/threadIdToModeratorTokenMap';
+import { getAdminUser, getToken } from '../lib/identityClient';
 
 const router = express.Router();
 interface AddUserParam {
@@ -26,20 +27,32 @@ interface AddUserParam {
 router.post('/:threadId', async function (req, res, next) {
   const addUserParam: AddUserParam = req.body;
   const threadId = req.params['threadId'];
-  const moderatorCredential = threadIdToModeratorCredentialMap.get(threadId);
 
-  const chatClient = new ChatClient(getEndpoint(), moderatorCredential);
+  // create a user from the adminUserId and create a credential around that
+  const credential = new AzureCommunicationTokenCredential({
+    tokenRefresher: async () => (await getToken(getAdminUser(), ['chat', 'voip'])).token,
+    refreshProactively: true
+  });
+
+  const chatClient = new ChatClient(getEndpoint(), credential);
   const chatThreadClient = await chatClient.getChatThreadClient(threadId);
 
-  await chatThreadClient.addParticipants({
-    participants: [
-      {
-        id: { communicationUserId: addUserParam.Id },
-        displayName: addUserParam.DisplayName
-      }
-    ]
-  });
-  res.sendStatus(201);
+  try {
+    await chatThreadClient.addParticipants({
+      participants: [
+        {
+          id: { communicationUserId: addUserParam.Id },
+          displayName: addUserParam.DisplayName
+        }
+      ]
+    });
+    res.sendStatus(201);
+  } catch (err) {
+    // we will return a 404 if the thread to join is not accessible by the server user.
+    // The server user needs to be in the thread in order to add someone.
+    // So we are returning back that we can't find the thread to add the client user to.
+    res.sendStatus(404);
+  }
 });
 
 export default router;


### PR DESCRIPTION
## Purpose

We updated the server code where we maintain our sample code for our hero samples and I am updating the code to be consistent with the ui-library repo. The additional setting isn't used in the calling hero sample but its better for us to be consistent just in case. 

The adminUserId is meant to be the user id of a user made from the same Azure Communications Service resource as the connection string used in the appsettings.json. There was an issue where we only maintained chat threads in in-memory storage which meant server restarts meant you had to create a new chat thread. Now that we force a static adminUserId, when restarting the server you will be able to use previously created threads associated with the static adminUserId.

## Pull Request Type

<!-- What kind of change does this Pull Request introduce? -->
<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```